### PR TITLE
🐛(env.d) fix env compatibility issue with docker compose 2.7.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -355,66 +355,11 @@ workflows:
                 name: no-change-cnfpt
     demo:
         jobs:
-            - check-changelog:
-                filters:
-                    branches:
-                        ignore: main
-                name: check-changelog-demo
-                site: demo
-            - lint-changelog:
-                filters:
-                    branches:
-                        ignore: main
-                    tags:
-                        only: /demo-.*/
-                name: lint-changelog--demo
-                site: demo
-            - build-front-production:
+            - no-change:
                 filters:
                     tags:
-                        only: /demo-.*/
-                name: build-front-production-demo
-                site: demo
-            - lint-front:
-                filters:
-                    tags:
-                        only: /demo-.*/
-                name: lint-front-demo
-                requires:
-                    - build-front-production-demo
-                site: demo
-            - build-back:
-                filters:
-                    tags:
-                        only: /demo-.*/
-                name: build-back-demo
-                site: demo
-            - lint-back:
-                filters:
-                    tags:
-                        only: /demo-.*/
-                name: lint-back-demo
-                requires:
-                    - build-back-demo
-                site: demo
-            - test-back:
-                filters:
-                    tags:
-                        only: /demo-.*/
-                name: test-back-demo
-                requires:
-                    - build-back-demo
-                site: demo
-            - hub:
-                filters:
-                    tags:
-                        only: /^demo-.*/
-                image_name: richie-demo
-                name: hub-demo
-                requires:
-                    - lint-front-demo
-                    - lint-back-demo
-                site: demo
+                        only: /.*/
+                name: no-change-demo
     funcampus:
         jobs:
             - no-change:
@@ -431,66 +376,11 @@ workflows:
                 name: no-change-funcorporate
     funmooc:
         jobs:
-            - check-changelog:
-                filters:
-                    branches:
-                        ignore: main
-                name: check-changelog-funmooc
-                site: funmooc
-            - lint-changelog:
-                filters:
-                    branches:
-                        ignore: main
-                    tags:
-                        only: /funmooc-.*/
-                name: lint-changelog--funmooc
-                site: funmooc
-            - build-front-production:
+            - no-change:
                 filters:
                     tags:
-                        only: /funmooc-.*/
-                name: build-front-production-funmooc
-                site: funmooc
-            - lint-front:
-                filters:
-                    tags:
-                        only: /funmooc-.*/
-                name: lint-front-funmooc
-                requires:
-                    - build-front-production-funmooc
-                site: funmooc
-            - build-back:
-                filters:
-                    tags:
-                        only: /funmooc-.*/
-                name: build-back-funmooc
-                site: funmooc
-            - lint-back:
-                filters:
-                    tags:
-                        only: /funmooc-.*/
-                name: lint-back-funmooc
-                requires:
-                    - build-back-funmooc
-                site: funmooc
-            - test-back:
-                filters:
-                    tags:
-                        only: /funmooc-.*/
-                name: test-back-funmooc
-                requires:
-                    - build-back-funmooc
-                site: funmooc
-            - hub:
-                filters:
-                    tags:
-                        only: /^funmooc-.*/
-                image_name: funmooc
-                name: hub-funmooc
-                requires:
-                    - lint-front-funmooc
-                    - lint-back-funmooc
-                site: funmooc
+                        only: /.*/
+                name: no-change-funmooc
     site-factory:
         jobs:
             - lint-git:
@@ -498,7 +388,7 @@ workflows:
                     tags:
                         only: /.*/
             - check-configuration:
-                ci_update_options: ""
+                ci_update_options: --ignore-changelog
                 filters:
                     branches:
                         ignore: main

--- a/env.d/development
+++ b/env.d/development
@@ -27,7 +27,7 @@ DJANGO_SOCIAL_AUTH_EDX_OAUTH2_SECRET=fakesecret
 # LMS Backend
 EDX_BACKEND=richie.apps.courses.lms.base.BaseLMSBackend
 EDX_JS_BACKEND=dummy
-EDX_JS_COURSE_REGEX=^.*/courses/(.*)/info$
+EDX_JS_COURSE_REGEX='^.*/courses/(.*)/info$'
 EDX_BASE_URL=http://localhost:8073
 
 # Authentication Backend


### PR DESCRIPTION
## Purpose

Since docker compose 2.7.0, there is an "Invalid template" error when a
environment variable which is a regex is not quoted. This is the case of
`EDX_SELECTOR_REGEX` and `EDX_COURSE_REGEX`. So we quote those two variables.


## Proposal

- [x] Quote environment variables that are regex within env.d 
