### PR TITLE
💚(site_jobs) prefix all filter tags regex with ^

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -341,190 +341,25 @@ version: 2.1
 workflows:
     ademe:
         jobs:
-            - check-changelog:
-                filters:
-                    branches:
-                        ignore: /.*/
-                name: check-changelog-ademe
-                site: ademe
-            - lint-changelog:
-                filters:
-                    branches:
-                        ignore: main
-                    tags:
-                        only: /ademe-.*/
-                name: lint-changelog--ademe
-                site: ademe
-            - build-front-production:
+            - no-change:
                 filters:
                     tags:
-                        only: /ademe-.*/
-                name: build-front-production-ademe
-                site: ademe
-            - lint-front:
-                filters:
-                    tags:
-                        only: /ademe-.*/
-                name: lint-front-ademe
-                requires:
-                    - build-front-production-ademe
-                site: ademe
-            - build-back:
-                filters:
-                    tags:
-                        only: /ademe-.*/
-                name: build-back-ademe
-                site: ademe
-            - lint-back:
-                filters:
-                    tags:
-                        only: /ademe-.*/
-                name: lint-back-ademe
-                requires:
-                    - build-back-ademe
-                site: ademe
-            - test-back:
-                filters:
-                    tags:
-                        only: /ademe-.*/
-                name: test-back-ademe
-                requires:
-                    - build-back-ademe
-                site: ademe
-            - hub:
-                filters:
-                    tags:
-                        only: /^ademe-.*/
-                image_name: ademe
-                name: hub-ademe
-                requires:
-                    - lint-front-ademe
-                    - lint-back-ademe
-                site: ademe
+                        only: /.*/
+                name: no-change-ademe
     cnfpt:
         jobs:
-            - check-changelog:
-                filters:
-                    branches:
-                        ignore: /.*/
-                name: check-changelog-cnfpt
-                site: cnfpt
-            - lint-changelog:
-                filters:
-                    branches:
-                        ignore: main
-                    tags:
-                        only: /cnfpt-.*/
-                name: lint-changelog--cnfpt
-                site: cnfpt
-            - build-front-production:
+            - no-change:
                 filters:
                     tags:
-                        only: /cnfpt-.*/
-                name: build-front-production-cnfpt
-                site: cnfpt
-            - lint-front:
-                filters:
-                    tags:
-                        only: /cnfpt-.*/
-                name: lint-front-cnfpt
-                requires:
-                    - build-front-production-cnfpt
-                site: cnfpt
-            - build-back:
-                filters:
-                    tags:
-                        only: /cnfpt-.*/
-                name: build-back-cnfpt
-                site: cnfpt
-            - lint-back:
-                filters:
-                    tags:
-                        only: /cnfpt-.*/
-                name: lint-back-cnfpt
-                requires:
-                    - build-back-cnfpt
-                site: cnfpt
-            - test-back:
-                filters:
-                    tags:
-                        only: /cnfpt-.*/
-                name: test-back-cnfpt
-                requires:
-                    - build-back-cnfpt
-                site: cnfpt
-            - hub:
-                filters:
-                    tags:
-                        only: /^cnfpt-.*/
-                image_name: cnfpt
-                name: hub-cnfpt
-                requires:
-                    - lint-front-cnfpt
-                    - lint-back-cnfpt
-                site: cnfpt
+                        only: /.*/
+                name: no-change-cnfpt
     demo:
         jobs:
-            - check-changelog:
-                filters:
-                    branches:
-                        ignore: /.*/
-                name: check-changelog-demo
-                site: demo
-            - lint-changelog:
-                filters:
-                    branches:
-                        ignore: main
-                    tags:
-                        only: /demo-.*/
-                name: lint-changelog--demo
-                site: demo
-            - build-front-production:
+            - no-change:
                 filters:
                     tags:
-                        only: /demo-.*/
-                name: build-front-production-demo
-                site: demo
-            - lint-front:
-                filters:
-                    tags:
-                        only: /demo-.*/
-                name: lint-front-demo
-                requires:
-                    - build-front-production-demo
-                site: demo
-            - build-back:
-                filters:
-                    tags:
-                        only: /demo-.*/
-                name: build-back-demo
-                site: demo
-            - lint-back:
-                filters:
-                    tags:
-                        only: /demo-.*/
-                name: lint-back-demo
-                requires:
-                    - build-back-demo
-                site: demo
-            - test-back:
-                filters:
-                    tags:
-                        only: /demo-.*/
-                name: test-back-demo
-                requires:
-                    - build-back-demo
-                site: demo
-            - hub:
-                filters:
-                    tags:
-                        only: /^demo-.*/
-                image_name: richie-demo
-                name: hub-demo
-                requires:
-                    - lint-front-demo
-                    - lint-back-demo
-                site: demo
+                        only: /.*/
+                name: no-change-demo
     funcampus:
         jobs:
             - no-change:

--- a/.circleci/src/workflows/site_jobs.yml.tpl
+++ b/.circleci/src/workflows/site_jobs.yml.tpl
@@ -15,7 +15,7 @@ ${SITE}:
           branches:
             ignore: main
           tags:
-            only: /${SITE}-.*/
+            only: /^${SITE}-.*/
 
     # Front-end jobs
     #
@@ -25,7 +25,7 @@ ${SITE}:
         site: ${SITE}
         filters:
           tags:
-            only: /${SITE}-.*/
+            only: /^${SITE}-.*/
     - lint-front:
         name: lint-front-${SITE}
         site: ${SITE}
@@ -33,7 +33,7 @@ ${SITE}:
           - build-front-production-${SITE}
         filters:
           tags:
-            only: /${SITE}-.*/
+            only: /^${SITE}-.*/
 
     # Backend jobs
     #
@@ -44,7 +44,7 @@ ${SITE}:
         site: ${SITE}
         filters:
           tags:
-            only: /${SITE}-.*/
+            only: /^${SITE}-.*/
     - lint-back:
         name: lint-back-${SITE}
         site: ${SITE}
@@ -52,7 +52,7 @@ ${SITE}:
           - build-back-${SITE}
         filters:
           tags:
-            only: /${SITE}-.*/
+            only: /^${SITE}-.*/
     - test-back:
         name: test-back-${SITE}
         site: ${SITE}
@@ -60,7 +60,7 @@ ${SITE}:
           - build-back-${SITE}
         filters:
           tags:
-            only: /${SITE}-.*/
+            only: /^${SITE}-.*/
 
     # DockerHub publication.
     #


### PR DESCRIPTION
## Purpose

We generate automatically circle ci configuration file according to modification. But currently, except for the job "hub", filter tag expression is not prefix by a '^'. It could lead to a misbehaviour if a site name includes another site name.

e.g :
If we have two sites : 
- demo
- ademo

ademo tags will also trigger jobs of demo site : `demo-.*` and `ademo-.*`

## Proposal 
- [x] Prefix filter tags with a `^` (e.g: `demo-.*` -> `^demo-.*`)