### PR TITLE
💬(funmooc) change help button label into FAQ

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -376,11 +376,66 @@ workflows:
                 name: no-change-funcorporate
     funmooc:
         jobs:
-            - no-change:
+            - check-changelog:
+                filters:
+                    branches:
+                        ignore: main
+                name: check-changelog-funmooc
+                site: funmooc
+            - lint-changelog:
+                filters:
+                    branches:
+                        ignore: main
+                    tags:
+                        only: /^funmooc-.*/
+                name: lint-changelog--funmooc
+                site: funmooc
+            - build-front-production:
                 filters:
                     tags:
-                        only: /.*/
-                name: no-change-funmooc
+                        only: /^funmooc-.*/
+                name: build-front-production-funmooc
+                site: funmooc
+            - lint-front:
+                filters:
+                    tags:
+                        only: /^funmooc-.*/
+                name: lint-front-funmooc
+                requires:
+                    - build-front-production-funmooc
+                site: funmooc
+            - build-back:
+                filters:
+                    tags:
+                        only: /^funmooc-.*/
+                name: build-back-funmooc
+                site: funmooc
+            - lint-back:
+                filters:
+                    tags:
+                        only: /^funmooc-.*/
+                name: lint-back-funmooc
+                requires:
+                    - build-back-funmooc
+                site: funmooc
+            - test-back:
+                filters:
+                    tags:
+                        only: /^funmooc-.*/
+                name: test-back-funmooc
+                requires:
+                    - build-back-funmooc
+                site: funmooc
+            - hub:
+                filters:
+                    tags:
+                        only: /^funmooc-.*/
+                image_name: funmooc
+                name: hub-funmooc
+                requires:
+                    - lint-front-funmooc
+                    - lint-back-funmooc
+                site: funmooc
     site-factory:
         jobs:
             - lint-git:
@@ -388,7 +443,7 @@ workflows:
                     tags:
                         only: /.*/
             - check-configuration:
-                ci_update_options: --ignore-changelog
+                ci_update_options: ""
                 filters:
                     branches:
                         ignore: main

--- a/sites/funmooc/CHANGELOG.md
+++ b/sites/funmooc/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Change help button label to "FAQ"
 - Upgrade richie to 2.15.1
 
 ## [1.18.0] - 2022-07-28

--- a/sites/funmooc/src/backend/locale/fr/LC_MESSAGES/django.po
+++ b/sites/funmooc/src/backend/locale/fr/LC_MESSAGES/django.po
@@ -110,8 +110,8 @@ msgid "French"
 msgstr "Français"
 
 #: templates/richie/base.html:18
-msgid "Help"
-msgstr "Aide"
+msgid "FAQ"
+msgstr "FAQ"
 
 #: templates/richie/base.html:28
 msgid "https://www.france-universite-numerique.fr/en/"

--- a/sites/funmooc/src/backend/templates/richie/base.html
+++ b/sites/funmooc/src/backend/templates/richie/base.html
@@ -15,7 +15,7 @@
 
 {% block topbar_contact %}
 <li class="topbar__item topbar__item--cta">
-    <a href="{% page_url 'help' %}">{% trans "Help" %}</a>
+    <a href="{% page_url 'help' %}">{% trans "FAQ" %}</a>
 </li>
 {% endblock topbar_contact %}
 


### PR DESCRIPTION
## Purpose

The "help" button now redirects to a FAQ page so we want also to change the label of this button to "FAQ".

### Before
<img width="237" alt="image" src="https://user-images.githubusercontent.com/9265241/184095752-4faa86a2-4927-4cec-8bc8-5531ba693939.png">

### After
<img width="216" alt="image" src="https://user-images.githubusercontent.com/9265241/184095797-6af05c1b-cf45-427d-9cdc-de62de040e6f.png">


## Proposal