### PR TITLE
📈(xiti) migrate to piano analytics

### DIFF
--- a/sites/funmooc/CHANGELOG.md
+++ b/sites/funmooc/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Migrate web analytics to piano analytics
 - Change help button label to "FAQ"
 - Upgrade richie to 2.15.1
 

--- a/sites/funmooc/src/frontend/js/utils/api/web-analytics/xiti.ts
+++ b/sites/funmooc/src/frontend/js/utils/api/web-analytics/xiti.ts
@@ -10,26 +10,26 @@ import { BaseWebAnalyticsApi } from 'richie-education/js/utils/api/web-analytics
  *
  */
 export default class FunXitiApi extends BaseWebAnalyticsApi {
-  tag: any;
+  PA: any;
 
   constructor() {
     super();
 
-    const smartTag = (window as any)?.smartTag;
+    const PA = (window as any)?.PA;
 
     // User has denied being tracked or an adblocker has blocked the tag initialization.
-    if (smartTag === undefined) {
+    if (PA === undefined) {
       return;
     }
 
-    this.tag = smartTag.tag;
+    this.PA = PA;
   }
 
   sendEvent(category: string, action: string, label: string): void {
-    this.tag?.setProp('s:resource_link', label, false);
-    this.tag?.click.send({
-      name: category,
-      type: 'action',
+    this.PA?.tag.sendEvent('click.action', {
+      ...this.PA?.data,
+      click: category,
+      's:resource_link': label,
     });
   }
 }


### PR DESCRIPTION
## Purpose
ATInternet will deprecate soon its Analytics Suite 2 in favor of Piano Analytics. Currently, to send analytic events we are using smartTag SDK which is able to send data to Piano Analytics but not in an optimal way.
So we take the opportunity of the deprecation of AS2 to switch to the new Piano Analytics SDK to send analytics event.

## Proposal
- [x] Migrate to the new [Piano Analytics SDK](https://developers.atinternet-solutions.com/piano-analytics/)