### PR TITLE
🐛(funmooc) fix xiti issues when a page has only one organization

### DIFF
--- a/sites/funmooc/CHANGELOG.md
+++ b/sites/funmooc/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Xiti issues when a course page has only one organization. 
+
 ## [1.19.0] - 2022-10-18
 
 ### Changed

--- a/sites/funmooc/src/backend/base/static/funmooc/js/xiti.js
+++ b/sites/funmooc/src/backend/base/static/funmooc/js/xiti.js
@@ -3,16 +3,17 @@
    * Deserialize a context analytic dimension
    *
    * @param dimension - string with items joined by ' | '
+   * @param toArray - flag to enforce to return result as Array
    * @return data
-   *    - undefined if the dimension string was empty
-   *    - A single value if the dimension cannot be split
-   *    - An array of value if dimension has been split
+   *    - [] || undefined if the dimension string was empty
+   *    - [value] or value if the dimension cannot be split
+   *    - An array of values if dimension has been split
    */
-  function deserialize(dimension) {
+  function deserialize(dimension, toArray = false) {
     const data = dimension.split(' | ');
     if (data.length === 1) {
-      if (!data[0].trim()) return undefined;
-      return data[0];
+      if (!data[0].trim()) return toArray ? [] : undefined;
+      return toArray ? data : data[0];
     }
     return data;
   }
@@ -37,7 +38,7 @@
   function PATag(metadata) {
     this.data = null;
     this.level2 = metadata.dimensions.root_page_id;
-    this.organizations = deserialize(metadata.dimensions.organizations_codes);
+    this.organizations = deserialize(metadata.dimensions.organizations_codes, true);
     this.siteId = metadata.id;
     this.tag = null;
 


### PR DESCRIPTION
## Purpose
The method to deserialize an analytic dimension returned a single value when the dimension could not be split. But, about organizations, we need to always manage an array so in the case where a page contained only one organization, the xiti tag initialization failed. 

https://sentry.io/share/issue/b30cd972525c4313b4814adf5743aaf1/

## Proposal 
- [x] Add an argument `toArray` to the deserialize method to enforce output to be an array if needed