### PR TITLE
♿  a11y/empty course label

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -403,190 +403,25 @@ workflows:
                 site: ademe
     demo:
         jobs:
-            - check-changelog:
-                filters:
-                    branches:
-                        ignore: main
-                name: check-changelog-demo
-                site: demo
-            - lint-changelog:
-                filters:
-                    branches:
-                        ignore: main
-                    tags:
-                        only: /^demo-.*/
-                name: lint-changelog--demo
-                site: demo
-            - build-front-production:
+            - no-change:
                 filters:
                     tags:
-                        only: /^demo-.*/
-                name: build-front-production-demo
-                site: demo
-            - lint-front:
-                filters:
-                    tags:
-                        only: /^demo-.*/
-                name: lint-front-demo
-                requires:
-                    - build-front-production-demo
-                site: demo
-            - build-back:
-                filters:
-                    tags:
-                        only: /^demo-.*/
-                name: build-back-demo
-                site: demo
-            - lint-back:
-                filters:
-                    tags:
-                        only: /^demo-.*/
-                name: lint-back-demo
-                requires:
-                    - build-back-demo
-                site: demo
-            - test-back:
-                filters:
-                    tags:
-                        only: /^demo-.*/
-                name: test-back-demo
-                requires:
-                    - build-back-demo
-                site: demo
-            - hub:
-                filters:
-                    tags:
-                        only: /^demo-.*/
-                image_name: richie-demo
-                name: hub-demo
-                requires:
-                    - lint-front-demo
-                    - lint-back-demo
-                site: demo
+                        only: /.*/
+                name: no-change-demo
     funcampus:
         jobs:
-            - check-changelog:
-                filters:
-                    branches:
-                        ignore: main
-                name: check-changelog-funcampus
-                site: funcampus
-            - lint-changelog:
-                filters:
-                    branches:
-                        ignore: main
-                    tags:
-                        only: /^funcampus-.*/
-                name: lint-changelog--funcampus
-                site: funcampus
-            - build-front-production:
+            - no-change:
                 filters:
                     tags:
-                        only: /^funcampus-.*/
-                name: build-front-production-funcampus
-                site: funcampus
-            - lint-front:
-                filters:
-                    tags:
-                        only: /^funcampus-.*/
-                name: lint-front-funcampus
-                requires:
-                    - build-front-production-funcampus
-                site: funcampus
-            - build-back:
-                filters:
-                    tags:
-                        only: /^funcampus-.*/
-                name: build-back-funcampus
-                site: funcampus
-            - lint-back:
-                filters:
-                    tags:
-                        only: /^funcampus-.*/
-                name: lint-back-funcampus
-                requires:
-                    - build-back-funcampus
-                site: funcampus
-            - test-back:
-                filters:
-                    tags:
-                        only: /^funcampus-.*/
-                name: test-back-funcampus
-                requires:
-                    - build-back-funcampus
-                site: funcampus
-            - hub:
-                filters:
-                    tags:
-                        only: /^funcampus-.*/
-                image_name: funcampus
-                name: hub-funcampus
-                requires:
-                    - lint-front-funcampus
-                    - lint-back-funcampus
-                site: funcampus
+                        only: /.*/
+                name: no-change-funcampus
     funcorporate:
         jobs:
-            - check-changelog:
-                filters:
-                    branches:
-                        ignore: main
-                name: check-changelog-funcorporate
-                site: funcorporate
-            - lint-changelog:
-                filters:
-                    branches:
-                        ignore: main
-                    tags:
-                        only: /^funcorporate-.*/
-                name: lint-changelog--funcorporate
-                site: funcorporate
-            - build-front-production:
+            - no-change:
                 filters:
                     tags:
-                        only: /^funcorporate-.*/
-                name: build-front-production-funcorporate
-                site: funcorporate
-            - lint-front:
-                filters:
-                    tags:
-                        only: /^funcorporate-.*/
-                name: lint-front-funcorporate
-                requires:
-                    - build-front-production-funcorporate
-                site: funcorporate
-            - build-back:
-                filters:
-                    tags:
-                        only: /^funcorporate-.*/
-                name: build-back-funcorporate
-                site: funcorporate
-            - lint-back:
-                filters:
-                    tags:
-                        only: /^funcorporate-.*/
-                name: lint-back-funcorporate
-                requires:
-                    - build-back-funcorporate
-                site: funcorporate
-            - test-back:
-                filters:
-                    tags:
-                        only: /^funcorporate-.*/
-                name: test-back-funcorporate
-                requires:
-                    - build-back-funcorporate
-                site: funcorporate
-            - hub:
-                filters:
-                    tags:
-                        only: /^funcorporate-.*/
-                image_name: funcorporate
-                name: hub-funcorporate
-                requires:
-                    - lint-front-funcorporate
-                    - lint-back-funcorporate
-                site: funcorporate
+                        only: /.*/
+                name: no-change-funcorporate
     funmooc:
         jobs:
             - check-changelog:

--- a/sites/ademe/CHANGELOG.md
+++ b/sites/ademe/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Improve accessibility by using lighter color for empty course label
+
 ## [0.12.0] - 2023-01-16
 
 ### Changed

--- a/sites/ademe/src/frontend/scss/extras/colors/_theme.scss
+++ b/sites/ademe/src/frontend/scss/extras/colors/_theme.scss
@@ -92,7 +92,7 @@ $r-theme: map-merge($r-theme,
     background-image: url("../../richie/images/components/wave-white.svg"),
   ),
   block-schemes: (
-    empty-color: r-color("battleship-grey"),
+    empty-color: r-color("pale-grey"),
     divider: r-color("pale-grey"),
     variants: (
       clear: $peppermint-scheme,

--- a/sites/funmooc/CHANGELOG.md
+++ b/sites/funmooc/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Improve accessibility by using lighter color for empty course label
+
 ## [1.21.0] - 2023-01-16
 
 ### Changed

--- a/sites/funmooc/src/frontend/scss/extras/colors/_theme.scss
+++ b/sites/funmooc/src/frontend/scss/extras/colors/_theme.scss
@@ -93,7 +93,7 @@ $r-theme: map-merge($r-theme, (
     background-image: url('../../richie/images/components/wave-white.svg'),
   ),
   block-schemes: (
-    empty-color: r-color('brownish-grey'),
+    empty-color: r-color('silver'),
     divider: r-color('pale-grey'),
     variants: (
       clear: $light-scheme,


### PR DESCRIPTION
## Purpose
When no opened course runs are available, a label is displayed to explain that to the user but currently the shade difference between the color label and its background does not comply with RGAA on FUN Mooc and Ademe sites.

### ⚠️ About Ademe

**It appears that currently a light color on a tealish background does not comply
at all with RGAA!** The only color that could be used is black. But currently, all
text in the course subheader is white so if we use a black color for this label
only we are breaking ui consistency.

In other hand, the new constrast color norm used by the WCAG next version 3,
APCA, challenges RGAA in this case. It appears that a pale-grey 16px bold text on a
tealish background could comply with APCA. So as a take-off, in order to improve
accessibility and keep ui consistency, we could use a 'pale-grey' color for this
label.
<img width="721" alt="Capture d’écran 2023-02-02 à 11 46 14" src="https://user-images.githubusercontent.com/9265241/216313567-968bf1c9-533c-4492-b9e7-76dad77a6f01.png">
<img width="986" alt="Capture d’écran 2023-02-02 à 11 46 49" src="https://user-images.githubusercontent.com/9265241/216313568-7cb411ab-99a3-4a31-84a9-67d251c4546f.png">

<img width="1002" alt="Capture d’écran 2023-02-02 à 11 48 10" src="https://user-images.githubusercontent.com/9265241/216313553-cadcbc0a-1fdd-445f-9f2d-40442a8ed7b1.png">


### About FUN Mooc
A good takeoff seems to use the "silver" color which fulfill RGAA contrast criteria and is dark enough to understand that something is "disabled".
<img width="725" alt="Capture d’écran 2023-02-02 à 11 25 36" src="https://user-images.githubusercontent.com/9265241/216313248-cd9b26f7-5bee-46a0-8107-211c2b0413ba.png">

<img width="1025" alt="Capture d’écran 2023-02-02 à 12 23 09" src="https://user-images.githubusercontent.com/9265241/216313273-bacf110a-e80c-4e5b-a309-82a784a58119.png">


## Proposal

- [x] Update scheme-block.empty-color to use a lighter color on FUN Mooc and Ademe