### PR TITLE
✨(ademe) add redirect for OpenEdX course urls

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -341,11 +341,66 @@ version: 2.1
 workflows:
     ademe:
         jobs:
-            - no-change:
+            - check-changelog:
+                filters:
+                    branches:
+                        ignore: main
+                name: check-changelog-ademe
+                site: ademe
+            - lint-changelog:
+                filters:
+                    branches:
+                        ignore: main
+                    tags:
+                        only: /^ademe-.*/
+                name: lint-changelog--ademe
+                site: ademe
+            - build-front-production:
                 filters:
                     tags:
-                        only: /.*/
-                name: no-change-ademe
+                        only: /^ademe-.*/
+                name: build-front-production-ademe
+                site: ademe
+            - lint-front:
+                filters:
+                    tags:
+                        only: /^ademe-.*/
+                name: lint-front-ademe
+                requires:
+                    - build-front-production-ademe
+                site: ademe
+            - build-back:
+                filters:
+                    tags:
+                        only: /^ademe-.*/
+                name: build-back-ademe
+                site: ademe
+            - lint-back:
+                filters:
+                    tags:
+                        only: /^ademe-.*/
+                name: lint-back-ademe
+                requires:
+                    - build-back-ademe
+                site: ademe
+            - test-back:
+                filters:
+                    tags:
+                        only: /^ademe-.*/
+                name: test-back-ademe
+                requires:
+                    - build-back-ademe
+                site: ademe
+            - hub:
+                filters:
+                    tags:
+                        only: /^ademe-.*/
+                image_name: ademe
+                name: hub-ademe
+                requires:
+                    - lint-front-ademe
+                    - lint-back-ademe
+                site: ademe
     demo:
         jobs:
             - no-change:

--- a/sites/ademe/CHANGELOG.md
+++ b/sites/ademe/CHANGELOG.md
@@ -9,6 +9,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Redirect old OpenEdX course urls to new richie course pages
+
 ## [0.18.0] - 2023-10-05
 
 ### Changed

--- a/sites/ademe/src/backend/ademe/urls.py
+++ b/sites/ademe/src/backend/ademe/urls.py
@@ -33,6 +33,7 @@ urlpatterns = [
         include([*courses_urlpatterns, *search_urlpatterns, *plugins_urlpatterns]),
     ),
     re_path(r"^redirects/", include([*courses_redirects_urlpatterns])),
+    path(r"", include("base.urls")),
     path(r"", include("filer.server.urls")),
     path(r"django-check-seo/", include("django_check_seo.urls")),
 ]

--- a/sites/ademe/src/backend/base/tests/test_views.py
+++ b/sites/ademe/src/backend/base/tests/test_views.py
@@ -2,7 +2,108 @@
 from django.test import TestCase
 
 from lxml import etree  # nosec
-from richie.apps.core.factories import UserFactory
+from richie.apps.core.factories import PageFactory, TitleFactory, UserFactory
+from richie.apps.courses.factories import CourseFactory, OrganizationFactory
+
+
+class ResourcesEdxRedirectViewsTestCase(TestCase):
+    """Test the "redirect_edx_resources" view."""
+
+    def test_views_redirect_edx_courses_success(self):
+        """OpenEdX course urls are redirected to the corresponding page in richie."""
+        course = CourseFactory(
+            code="abc", page_title="Physique 101", should_publish=True
+        )
+        TitleFactory(page=course.extended_object, language="en", title="Physics 101")
+        course.extended_object.publish("en")
+
+        response = self.client.get("/courses/course-v1:sorbonne+abc+001/about/")
+
+        self.assertRedirects(
+            response,
+            "/fr/physique-101/",
+            status_code=301,
+            target_status_code=200,
+            fetch_redirect_response=True,
+        )
+
+    def test_views_redirect_edx_courses_success_with_old_course_uri(self):
+        """Old OpenEdX course urls are redirected to the corresponding page in richie."""
+        course = CourseFactory(
+            code="abc", page_title="Physique 101", should_publish=True
+        )
+        TitleFactory(page=course.extended_object, language="en", title="Physics 101")
+        course.extended_object.publish("en")
+
+        response = self.client.get("/courses/sorbonne/abc/001/about/")
+
+        self.assertRedirects(
+            response,
+            "/fr/physique-101/",
+            status_code=301,
+            target_status_code=200,
+            fetch_redirect_response=True,
+        )
+
+    def test_views_redirect_edx_courses_fallback_organization(self):
+        """
+        OpenEdX course urls are redirected to the organization page if the course page
+        can not be found.
+        """
+        OrganizationFactory(page_title="Sorbonne", code="sorbonne", should_publish=True)
+
+        response = self.client.get("/courses/course-v1:sorbonne+abc+001/about/")
+
+        self.assertRedirects(
+            response,
+            "/fr/sorbonne/",
+            status_code=301,
+            target_status_code=200,
+            fetch_redirect_response=True,
+        )
+
+    def test_views_redirect_edx_courses_fallback_search_page(self):
+        """
+        OpenEdX course urls are redirected to the search page if neither the course page
+        nor the organization page can be found.
+        """
+        PageFactory(
+            reverse_id="courses",
+            template="search/search.html",
+            title__title="Recherche",
+            title__language="fr",
+            should_publish=True,
+        )
+
+        response = self.client.get("/courses/course-v1:sorbonne+abc+001/about/")
+
+        self.assertRedirects(
+            response,
+            "/fr/recherche/",
+            status_code=301,
+            target_status_code=200,
+            fetch_redirect_response=True,
+        )
+
+    def test_views_redirect_edx_courses_no_fallback(self):
+        """
+        OpenEdX course urls are not redirected if the french version of the page is not
+        published (english is not yet activated on the public site).
+        """
+        course = CourseFactory(code="abc", page_title="Mon titre", should_publish=True)
+        TitleFactory(page=course.extended_object, language="en", title="My title")
+        course.extended_object.publish("en")
+        course.extended_object.unpublish("fr")
+
+        response = self.client.get("/courses/course-v1:org+abc+001/about/")
+
+        self.assertRedirects(
+            response,
+            "/fr/courses/course-v1:org+abc+001/about/",
+            status_code=302,
+            target_status_code=404,
+            fetch_redirect_response=True,
+        )
 
 
 class DjangoCheckSeoTestCase(TestCase):

--- a/sites/ademe/src/backend/base/urls.py
+++ b/sites/ademe/src/backend/base/urls.py
@@ -1,0 +1,21 @@
+"""
+API routes exposed by our base app.
+"""
+from django.urls import re_path
+
+from .views import redirect_edx_resources
+
+# Support both course OpenEdX routes
+#  http://open-fun.fr/courses/course-v1:acme+00001+session01/about
+#  http://open-fun.fr/courses/acme/00001/session01/about
+COURSE_KEY_PATTERN = (
+    r"(course-v1:)?(?P<organization>.+)(\/|\+)(?P<course>.+)(\/|\+)(?P<session>.+)"
+)
+
+urlpatterns = [
+    re_path(
+        r".*courses/{}/about/?$".format(COURSE_KEY_PATTERN),
+        redirect_edx_resources,
+        name="redirect_edx_courses",
+    ),
+]

--- a/sites/ademe/src/backend/base/views.py
+++ b/sites/ademe/src/backend/base/views.py
@@ -1,0 +1,42 @@
+"""Views for the fun-mooc site."""
+from django.db.models import Q
+from django.http import HttpResponsePermanentRedirect
+
+from cms.api import Page
+from cms.constants import PUBLISHER_STATE_PENDING
+from richie.apps.core.views.error import error_view_handler
+
+
+def redirect_edx_resources(request, organization, course=None, session=None):
+    """
+    The richie site is hosted on the same domain as OpenEdX before.
+    Redirect OpenEdX course/organization urls
+    to the corresponding Richie course/organization urls.
+    """
+
+    def get_redirect_url(**kwargs):
+        """Look for a published page matching the kwargs query filters."""
+        try:
+            page = Page.objects.get(
+                ~Q(title_set__publisher_state=PUBLISHER_STATE_PENDING),
+                publisher_is_draft=False,
+                title_set__language=request.LANGUAGE_CODE,
+                title_set__published=True,
+                **kwargs
+            )
+        except Page.DoesNotExist:
+            return
+
+        return page.get_absolute_url(request.LANGUAGE_CODE)
+
+    url = (
+        course is not None
+        and get_redirect_url(course__code__iexact=course)
+        or get_redirect_url(organization__code__iexact=organization)
+        or get_redirect_url(reverse_id="courses")
+    )
+
+    if url is None:
+        return error_view_handler(request, "Page not found", 404)
+
+    return HttpResponsePermanentRedirect(url)


### PR DESCRIPTION
## Purpose

Following migration of the Ademe site to richie, We don't want to lose all the traffic previously directed to course syllabus on OpenEdX. 

## Proposal

Add a view that catches these urls and tries to redirect them to the corresponding course detail page in Richie or resort to the search page.