### PR TITLE
💄(ademe) fix background color of active pagination item

### DIFF
--- a/sites/ademe/CHANGELOG.md
+++ b/sites/ademe/CHANGELOG.md
@@ -20,6 +20,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Add custom favicon
 - Redirect old OpenEdX course urls to new richie course pages
 
+### Fixed
+
+- Fix background-color of active pagination item
+
 ## [0.18.0] - 2023-10-05
 
 ### Changed

--- a/sites/ademe/src/frontend/scss/extras/colors/_theme.scss
+++ b/sites/ademe/src/frontend/scss/extras/colors/_theme.scss
@@ -276,7 +276,7 @@ $r-theme: map-merge(
       item-background: r-color('white'),
       item-border: r-color('silver'),
       current-color: r-color('white'),
-      current-background: r-color('dark-two'),
+      current-background: r-color('dark-aquamarine'),
     ),
     person-glimpse: (
       card-background: r-color('white'),


### PR DESCRIPTION
Currently, active pagination item has a black background that does not fit with the global website color palette. We replace this black color by dark-aquamarine in order to harmonize color palette.

|After|Before|
|-----|------|
|<img width="888" alt="image" src="https://github.com/openfun/fun-richie-site-factory/assets/9265241/979ae85d-7c1c-4d58-ae73-c932e5481fa6">|<img width="889" alt="image" src="https://github.com/openfun/fun-richie-site-factory/assets/9265241/1c977dcd-02b3-4c52-a783-62c097eafd39">|