### PR TITLE
📈(piano) pin JS SDK and configure to collect UTM parameters

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -396,66 +396,11 @@ version: 2.1
 workflows:
     ademe:
         jobs:
-            - check-changelog:
-                filters:
-                    branches:
-                        ignore: /.*/
-                name: check-changelog-ademe
-                site: ademe
-            - lint-changelog:
-                filters:
-                    branches:
-                        ignore: main
-                    tags:
-                        only: /^ademe-.*/
-                name: lint-changelog--ademe
-                site: ademe
-            - build-front-production:
+            - no-change:
                 filters:
                     tags:
-                        only: /^ademe-.*/
-                name: build-front-production-ademe
-                site: ademe
-            - lint-front:
-                filters:
-                    tags:
-                        only: /^ademe-.*/
-                name: lint-front-ademe
-                requires:
-                    - build-front-production-ademe
-                site: ademe
-            - build-back:
-                filters:
-                    tags:
-                        only: /^ademe-.*/
-                name: build-back-ademe
-                site: ademe
-            - lint-back:
-                filters:
-                    tags:
-                        only: /^ademe-.*/
-                name: lint-back-ademe
-                requires:
-                    - build-back-ademe
-                site: ademe
-            - test-back:
-                filters:
-                    tags:
-                        only: /^ademe-.*/
-                name: test-back-ademe
-                requires:
-                    - build-back-ademe
-                site: ademe
-            - hub:
-                filters:
-                    tags:
-                        only: /^ademe-.*/
-                image_name: ademe
-                name: hub-ademe
-                requires:
-                    - lint-front-ademe
-                    - lint-back-ademe
-                site: ademe
+                        only: /.*/
+                name: no-change-ademe
     canary:
         jobs:
             - hub-canary:
@@ -484,196 +429,31 @@ workflows:
                 - << pipeline.schedule.name >>
     demo:
         jobs:
-            - check-changelog:
-                filters:
-                    branches:
-                        ignore: /.*/
-                name: check-changelog-demo
-                site: demo
-            - lint-changelog:
-                filters:
-                    branches:
-                        ignore: main
-                    tags:
-                        only: /^demo-.*/
-                name: lint-changelog--demo
-                site: demo
-            - build-front-production:
+            - no-change:
                 filters:
                     tags:
-                        only: /^demo-.*/
-                name: build-front-production-demo
-                site: demo
-            - lint-front:
-                filters:
-                    tags:
-                        only: /^demo-.*/
-                name: lint-front-demo
-                requires:
-                    - build-front-production-demo
-                site: demo
-            - build-back:
-                filters:
-                    tags:
-                        only: /^demo-.*/
-                name: build-back-demo
-                site: demo
-            - lint-back:
-                filters:
-                    tags:
-                        only: /^demo-.*/
-                name: lint-back-demo
-                requires:
-                    - build-back-demo
-                site: demo
-            - test-back:
-                filters:
-                    tags:
-                        only: /^demo-.*/
-                name: test-back-demo
-                requires:
-                    - build-back-demo
-                site: demo
-            - hub:
-                filters:
-                    tags:
-                        only: /^demo-.*/
-                image_name: richie-demo
-                name: hub-demo
-                requires:
-                    - lint-front-demo
-                    - lint-back-demo
-                site: demo
+                        only: /.*/
+                name: no-change-demo
     funcampus:
         jobs:
-            - check-changelog:
-                filters:
-                    branches:
-                        ignore: /.*/
-                name: check-changelog-funcampus
-                site: funcampus
-            - lint-changelog:
-                filters:
-                    branches:
-                        ignore: main
-                    tags:
-                        only: /^funcampus-.*/
-                name: lint-changelog--funcampus
-                site: funcampus
-            - build-front-production:
+            - no-change:
                 filters:
                     tags:
-                        only: /^funcampus-.*/
-                name: build-front-production-funcampus
-                site: funcampus
-            - lint-front:
-                filters:
-                    tags:
-                        only: /^funcampus-.*/
-                name: lint-front-funcampus
-                requires:
-                    - build-front-production-funcampus
-                site: funcampus
-            - build-back:
-                filters:
-                    tags:
-                        only: /^funcampus-.*/
-                name: build-back-funcampus
-                site: funcampus
-            - lint-back:
-                filters:
-                    tags:
-                        only: /^funcampus-.*/
-                name: lint-back-funcampus
-                requires:
-                    - build-back-funcampus
-                site: funcampus
-            - test-back:
-                filters:
-                    tags:
-                        only: /^funcampus-.*/
-                name: test-back-funcampus
-                requires:
-                    - build-back-funcampus
-                site: funcampus
-            - hub:
-                filters:
-                    tags:
-                        only: /^funcampus-.*/
-                image_name: funcampus
-                name: hub-funcampus
-                requires:
-                    - lint-front-funcampus
-                    - lint-back-funcampus
-                site: funcampus
+                        only: /.*/
+                name: no-change-funcampus
     funcorporate:
         jobs:
-            - check-changelog:
-                filters:
-                    branches:
-                        ignore: /.*/
-                name: check-changelog-funcorporate
-                site: funcorporate
-            - lint-changelog:
-                filters:
-                    branches:
-                        ignore: main
-                    tags:
-                        only: /^funcorporate-.*/
-                name: lint-changelog--funcorporate
-                site: funcorporate
-            - build-front-production:
+            - no-change:
                 filters:
                     tags:
-                        only: /^funcorporate-.*/
-                name: build-front-production-funcorporate
-                site: funcorporate
-            - lint-front:
-                filters:
-                    tags:
-                        only: /^funcorporate-.*/
-                name: lint-front-funcorporate
-                requires:
-                    - build-front-production-funcorporate
-                site: funcorporate
-            - build-back:
-                filters:
-                    tags:
-                        only: /^funcorporate-.*/
-                name: build-back-funcorporate
-                site: funcorporate
-            - lint-back:
-                filters:
-                    tags:
-                        only: /^funcorporate-.*/
-                name: lint-back-funcorporate
-                requires:
-                    - build-back-funcorporate
-                site: funcorporate
-            - test-back:
-                filters:
-                    tags:
-                        only: /^funcorporate-.*/
-                name: test-back-funcorporate
-                requires:
-                    - build-back-funcorporate
-                site: funcorporate
-            - hub:
-                filters:
-                    tags:
-                        only: /^funcorporate-.*/
-                image_name: funcorporate
-                name: hub-funcorporate
-                requires:
-                    - lint-front-funcorporate
-                    - lint-back-funcorporate
-                site: funcorporate
+                        only: /.*/
+                name: no-change-funcorporate
     funmooc:
         jobs:
             - check-changelog:
                 filters:
                     branches:
-                        ignore: /.*/
+                        ignore: main
                 name: check-changelog-funmooc
                 site: funmooc
             - lint-changelog:
@@ -737,7 +517,7 @@ workflows:
                     tags:
                         only: /.*/
             - check-configuration:
-                ci_update_options: --ignore-changelog
+                ci_update_options: ""
                 filters:
                     branches:
                         ignore: main

--- a/sites/funmooc/CHANGELOG.md
+++ b/sites/funmooc/CHANGELOG.md
@@ -10,7 +10,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
-- Configure Piano Analytics to collect UTM parameters as a backup option
+- Change deprecated `xiti` web analytics service to `pianoanalytics`  
+- Configure Piano Analytics to also collect UTM parameters
 - Pin Piano Analytics JS SDK to 6.13.1
 
 ## [1.29.0-beta.0] - 2024-01-11

--- a/sites/funmooc/CHANGELOG.md
+++ b/sites/funmooc/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Configure Piano Analytics to collect UTM parameters as a backup option
+
 ## [1.29.0-beta.0] - 2024-01-11
 
 ### Changed

--- a/sites/funmooc/CHANGELOG.md
+++ b/sites/funmooc/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - Configure Piano Analytics to collect UTM parameters as a backup option
+- Pin Piano Analytics JS SDK to 6.13.1
 
 ## [1.29.0-beta.0] - 2024-01-11
 

--- a/sites/funmooc/src/backend/base/static/funmooc/js/pianoanalytics.js
+++ b/sites/funmooc/src/backend/base/static/funmooc/js/pianoanalytics.js
@@ -24,8 +24,8 @@
    *
    * @param metadata - analytics context
    *
-   *  - id: AT Internet site id to identify the site on Analytics Suite
-   *  - provider: 'xiti',
+   *  - id: Piano Analytics site id to identify the site on Analytics Suite
+   *  - provider: 'pianoanalytics',
    *  - dimensions: some serialized data related to the current page
    *    + course_code
    *    + course_runs_resource_links
@@ -43,7 +43,7 @@
     this.tag = null;
 
     /**
-     * Populate the data object sent to Xiti on dispatch.
+     * Populate the data object sent to Piano Analytics on dispatch.
      * It includes level2, name and chapters
      *
      * To get name and chapters we split the url pathname "/"
@@ -120,7 +120,7 @@
         this.tag = pa;
         this.tag.setConfigurations({
           campaignPrefix: ['at_', 'utm_'],
-          collectDomain: 'https://logs1409.xiti.com',
+          collectDomain: 'https://zqqzqjw.pa-cd.com',
           secure: true,
           site: this.siteId,
         });
@@ -166,18 +166,18 @@
     };
   }
 
-  // Find the xiti provider through all analytic providers then bind dimensions to the context
+  // Find the Piano Analytics provider through all analytic providers then bind dimensions to the context
   var context = window.__funmooc_context__.analytics.find(function (context) {
-    return context.provider === 'xiti';
+    return context.provider === 'pianoanalytics';
   });
   if (context === undefined) return;
   context.dimensions = window.__funmooc_context__.dimensions;
 
   tarteaucitron.services.paFun = {
-    key: 'xiti',
+    key: 'pianoanalytics',
     type: 'analytic',
     name: 'Piano Analytics',
-    uri: 'https://www.atinternet.com/societe/rgpd-et-vie-privee/',
+    uri: 'https://piano.io/privacy-policy/',
     needConsent: false,
     cookies: ['pa_vid', 'pa_privacy'],
     js: function () {

--- a/sites/funmooc/src/backend/base/static/funmooc/js/xiti.js
+++ b/sites/funmooc/src/backend/base/static/funmooc/js/xiti.js
@@ -181,7 +181,7 @@
     needConsent: false,
     cookies: ['pa_vid', 'pa_privacy'],
     js: function () {
-      var pa_url = 'https://tag.aticdn.net/piano-analytics.js';
+      var pa_url = 'https://tag.aticdn.net/js-sdk/piano-analytics-6.13.1.js';
       function onLoad() {
         const PA = new PATag(context);
         PA.init()

--- a/sites/funmooc/src/backend/base/static/funmooc/js/xiti.js
+++ b/sites/funmooc/src/backend/base/static/funmooc/js/xiti.js
@@ -119,6 +119,7 @@
       if (pa) {
         this.tag = pa;
         this.tag.setConfigurations({
+          campaignPrefix: ['at_', 'utm_'],
           collectDomain: 'https://logs1409.xiti.com',
           secure: true,
           site: this.siteId,

--- a/sites/funmooc/src/backend/base/tests/test_context_processors.py
+++ b/sites/funmooc/src/backend/base/tests/test_context_processors.py
@@ -15,8 +15,8 @@ class ContextProcessorsTestCase(TestCase):
     Test suite for the context processors
     """
 
-    @override_settings(WEB_ANALYTICS={"xiti": {"tracking_id": "123456"}})
-    def test_context_processors_add_xiti_settings_if_exists(self):
+    @override_settings(WEB_ANALYTICS={"pianoanalytics": {"tracking_id": "123456"}})
+    def test_context_processors_add_piano_settings_if_exists(self):
         """
         Create a page and make sure it includes web analytics context as included
         in `base.html`.
@@ -28,12 +28,12 @@ class ContextProcessorsTestCase(TestCase):
 
         response = self.client.get(page.get_public_url(), follow=True)
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, '"provider": "xiti"')
+        self.assertContains(response, '"provider": "pianoanalytics"')
         self.assertContains(response, '"id": "123456"')
         self.assertContains(response, f'"root_page_id": "{page.node.get_root().pk}"')
 
     @override_settings(WEB_ANALYTICS=None)
-    def test_context_processors_do_not_add_xiti_settings_if_marketing_site_id_is_not_defined(
+    def test_context_processors_do_not_add_piano_settings_if_marketing_site_id_is_not_defined(
         self,
     ):
         """
@@ -51,13 +51,13 @@ class ContextProcessorsTestCase(TestCase):
         self.assertNotContains(response, '"id": "')
         self.assertNotContains(response, f'"root_page_id": "{page.node.get_root().pk}"')
 
-    @override_settings(WEB_ANALYTICS={"xiti": {"tracking_id": "123456"}})
-    def test_context_processors_do_not_add_xiti_settings_if_page_is_draft(
+    @override_settings(WEB_ANALYTICS={"pianoanalytics": {"tracking_id": "123456"}})
+    def test_context_processors_do_not_add_piano_settings_if_page_is_draft(
         self,
     ):
         """
         If the current page is a draft,
-        frontend context should not contain xiti provider information
+        frontend context should not contain pianoanalytics provider information
         """
         user = UserFactory(is_staff=True, is_superuser=True)
         self.client.login(username=user.username, password="password")  # nosec
@@ -69,10 +69,10 @@ class ContextProcessorsTestCase(TestCase):
 
         response = self.client.get(page.get_absolute_url(), follow=True)
         self.assertEqual(response.status_code, 200)
-        self.assertNotContains(response, '"provider": "xiti"')
+        self.assertNotContains(response, '"provider": "pianoanalytics"')
         self.assertNotContains(response, '"id": "123456"')
 
-    @override_settings(WEB_ANALYTICS={"xiti": {"tracking_id": "123456"}})
+    @override_settings(WEB_ANALYTICS={"pianoanalytics": {"tracking_id": "123456"}})
     def test_context_processors_get_organizations_code(self):
         """
         If an organization is linked to the page or there are organization plugins on the page,
@@ -90,7 +90,7 @@ class ContextProcessorsTestCase(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIsNotNone(re.search(pattern, str(response.content)))
 
-    @override_settings(WEB_ANALYTICS={"xiti": {"tracking_id": "123456"}})
+    @override_settings(WEB_ANALYTICS={"pianoanalytics": {"tracking_id": "123456"}})
     def test_context_processors_retrieve_privacy_page_url_if_exists(self):
         """
         If a privacy policy page exists,
@@ -122,7 +122,7 @@ class ContextProcessorsTestCase(TestCase):
             response, f'"privacyUrl": "{privacy_page.get_public_url()}"'
         )
 
-    @override_settings(WEB_ANALYTICS={"xiti": {"tracking_id": "123456"}})
+    @override_settings(WEB_ANALYTICS={"pianoanalytics": {"tracking_id": "123456"}})
     def test_context_processors_queries_are_cached(self):
         """
         Once the page is cached, no db queries should be made again

--- a/sites/funmooc/src/backend/templates/richie/web_analytics.html
+++ b/sites/funmooc/src/backend/templates/richie/web_analytics.html
@@ -33,9 +33,9 @@
                     });
                 </script>
 
-                {% if provider == "xiti" %}
-                    <!-- Setup AT Internet -->
-                    <script type="text/javascript" src="{% static 'funmooc/js/xiti.js' %}"></script>
+                {% if provider == "pianoanalytics" %}
+                    <!-- Setup Piano Analytics -->
+                    <script type="text/javascript" src="{% static 'funmooc/js/pianoanalytics.js' %}"></script>
                 {% endif %}
             {% endif %}
         {% endif %}

--- a/sites/funmooc/src/frontend/js/api/web-analytics/index.ts
+++ b/sites/funmooc/src/frontend/js/api/web-analytics/index.ts
@@ -3,10 +3,10 @@ import { CourseProductEvent, WebAnalyticsAPI } from 'richie-education/js/types/w
 import context from 'richie-education/js/utils/context';
 import { handle } from 'richie-education/js/utils/errors/handle';
 // @ts-ignore
-import XitiApi from '../../../../../js/api/web-analytics/xiti';
+import PianoAnalyticsApi from '../../../../../js/api/web-analytics/pianoanalytics';
 
 enum FunMoocWebAnalyticsBackend {
-  XITI = 'xiti',
+  PIANOANALYTICS = 'pianoanalytics',
 }
 
 const WEB_ANALYTICS_PROVIDERS = context?.web_analytics_providers;
@@ -32,8 +32,8 @@ class WebAnalyticsAPIDelegator2Providers implements WebAnalyticsAPI {
 const WebAnalyticsAPIHandler = (): Maybe<WebAnalyticsAPIDelegator2Providers> => {
   const providers: WebAnalyticsAPI[] = [];
   try {
-    if (WEB_ANALYTICS_PROVIDERS?.includes(FunMoocWebAnalyticsBackend.XITI)) {
-      providers.push(new XitiApi());
+    if (WEB_ANALYTICS_PROVIDERS?.includes(FunMoocWebAnalyticsBackend.PIANOANALYTICS)) {
+      providers.push(new PianoAnalyticsApi());
     }
   } catch (error) {
     handle(error);

--- a/sites/funmooc/src/frontend/js/api/web-analytics/pianoanalytics.ts
+++ b/sites/funmooc/src/frontend/js/api/web-analytics/pianoanalytics.ts
@@ -3,13 +3,13 @@ import { BaseWebAnalyticsApi } from 'richie-education/js/api/web-analytics/base'
 
 /**
  *
- * Xiti Richie Web Analytics API Implementation
+ * Piano Analytics Richie Web Analytics API Implementation
  *
- * This implementation is used when web analytics is configured as `xiti`.
- * It will send events to the xiti.
+ * This implementation is used when web analytics is configured as `pianoanalytics`.
+ * It will send events to the piano analytics.
  *
  */
-export default class XitiApi extends BaseWebAnalyticsApi {
+export default class PianoAnalyticsApi extends BaseWebAnalyticsApi {
   PA: any;
 
   constructor() {


### PR DESCRIPTION
# Purpose

- Piano Analytics does not collect campaign marketing events with `utm_` prefix
- Web analytics integration uses the latest version available of the Piano JS SDK, exposing us to automatic upgrades and integration bugs

# Proposal

- Configure PA to also collect `utm_`-prefixed parameters
- Pin Piano Analytics JS SDK to 6.13.1
