### PR TITLE
💚(circle) replace deprecated images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,7 +83,7 @@ jobs:
         working_directory: ~/fun
     check-configuration:
         machine:
-            image: ubuntu-2004:202107-02
+            image: default
         parameters:
             ci_update_options:
                 type: string
@@ -450,66 +450,11 @@ workflows:
                 name: no-change-funcorporate
     funmooc:
         jobs:
-            - check-changelog:
-                filters:
-                    branches:
-                        ignore: main
-                name: check-changelog-funmooc
-                site: funmooc
-            - lint-changelog:
-                filters:
-                    branches:
-                        ignore: main
-                    tags:
-                        only: /^funmooc-.*/
-                name: lint-changelog--funmooc
-                site: funmooc
-            - build-front-production:
+            - no-change:
                 filters:
                     tags:
-                        only: /^funmooc-.*/
-                name: build-front-production-funmooc
-                site: funmooc
-            - lint-front:
-                filters:
-                    tags:
-                        only: /^funmooc-.*/
-                name: lint-front-funmooc
-                requires:
-                    - build-front-production-funmooc
-                site: funmooc
-            - build-back:
-                filters:
-                    tags:
-                        only: /^funmooc-.*/
-                name: build-back-funmooc
-                site: funmooc
-            - lint-back:
-                filters:
-                    tags:
-                        only: /^funmooc-.*/
-                name: lint-back-funmooc
-                requires:
-                    - build-back-funmooc
-                site: funmooc
-            - test-back:
-                filters:
-                    tags:
-                        only: /^funmooc-.*/
-                name: test-back-funmooc
-                requires:
-                    - build-back-funmooc
-                site: funmooc
-            - hub:
-                filters:
-                    tags:
-                        only: /^funmooc-.*/
-                image_name: funmooc
-                name: hub-funmooc
-                requires:
-                    - lint-front-funmooc
-                    - lint-back-funmooc
-                site: funmooc
+                        only: /.*/
+                name: no-change-funmooc
     site-factory:
         jobs:
             - lint-git:
@@ -517,7 +462,7 @@ workflows:
                     tags:
                         only: /.*/
             - check-configuration:
-                ci_update_options: ""
+                ci_update_options: --ignore-changelog
                 filters:
                     branches:
                         ignore: main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,7 @@ jobs:
         working_directory: ~/fun/sites/<< parameters.site >>/src/frontend/
     check-changelog:
         docker:
-            - image: cimg/base:2024.01
+            - image: cimg/base:current
         parameters:
             site:
                 type: string
@@ -98,7 +98,7 @@ jobs:
         docker:
             - environment:
                 RICHIE_SITE: << parameters.site >>
-              image: cimg/base:2024.01
+              image: cimg/base:current
         parameters:
             image_name:
                 type: string
@@ -189,7 +189,7 @@ jobs:
         docker:
             - environment:
                 RICHIE_SITE: << parameters.site >>
-              image: cimg/base:2024.01
+              image: cimg/base:current
         parameters:
             image_name:
                 type: string
@@ -336,7 +336,7 @@ jobs:
         working_directory: ~/fun
     no-change:
         docker:
-            - image: cimg/base:2024.01
+            - image: cimg/base:current
         steps:
             - run: echo "Everything is up-to-date ✅"
         working_directory: ~/fun

--- a/.circleci/src/jobs/@docker.yml
+++ b/.circleci/src/jobs/@docker.yml
@@ -7,7 +7,7 @@ hub:
     image_name:
       type: string
   docker:
-    - image: cimg/base:2024.01
+    - image: cimg/base:current
       environment:
         RICHIE_SITE: << parameters.site >>
   working_directory: ~/fun
@@ -118,7 +118,7 @@ hub-canary:
     image_name:
       type: string
   docker:
-    - image: cimg/base:2024.01
+    - image: cimg/base:current
       environment:
         RICHIE_SITE: << parameters.site >>
   working_directory: ~/fun

--- a/.circleci/src/jobs/@project.yml
+++ b/.circleci/src/jobs/@project.yml
@@ -35,7 +35,7 @@ check-configuration:
   # Use machine because the check_configuration script runs some docker images with
   # volume mounts which is not possible with dind
   machine:
-    image: ubuntu-2004:202107-02
+    image: default
   working_directory: ~/fun
   steps:
     - checkout

--- a/.circleci/src/jobs/@project.yml
+++ b/.circleci/src/jobs/@project.yml
@@ -61,7 +61,7 @@ check-changelog:
     site:
       type: string
   docker:
-    - image: cimg/base:2024.01
+    - image: cimg/base:current
   working_directory: ~/fun
   steps:
     - checkout
@@ -89,7 +89,7 @@ lint-changelog:
 # Check that the CHANGELOG max line length does not exceed 80 characters
 no-change:
   docker:
-    - image: cimg/base:2024.01
+    - image: cimg/base:current
   working_directory: ~/fun
   steps:
     - run: echo "Everything is up-to-date ✅"


### PR DESCRIPTION
Ubuntu images have been removed from circle-ci. We can use the default tags to
replace them.

Furthermore, the cimg/base image has a current tag we can use to avoid to have to
update them when circle will decide to remove old tags.