### PR TITLE
🩹️(funmooc) fix type issue that broke canary build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -396,66 +396,11 @@ version: 2.1
 workflows:
     ademe:
         jobs:
-            - check-changelog:
-                filters:
-                    branches:
-                        ignore: /.*/
-                name: check-changelog-ademe
-                site: ademe
-            - lint-changelog:
-                filters:
-                    branches:
-                        ignore: main
-                    tags:
-                        only: /^ademe-.*/
-                name: lint-changelog--ademe
-                site: ademe
-            - build-front-production:
+            - no-change:
                 filters:
                     tags:
-                        only: /^ademe-.*/
-                name: build-front-production-ademe
-                site: ademe
-            - lint-front:
-                filters:
-                    tags:
-                        only: /^ademe-.*/
-                name: lint-front-ademe
-                requires:
-                    - build-front-production-ademe
-                site: ademe
-            - build-back:
-                filters:
-                    tags:
-                        only: /^ademe-.*/
-                name: build-back-ademe
-                site: ademe
-            - lint-back:
-                filters:
-                    tags:
-                        only: /^ademe-.*/
-                name: lint-back-ademe
-                requires:
-                    - build-back-ademe
-                site: ademe
-            - test-back:
-                filters:
-                    tags:
-                        only: /^ademe-.*/
-                name: test-back-ademe
-                requires:
-                    - build-back-ademe
-                site: ademe
-            - hub:
-                filters:
-                    tags:
-                        only: /^ademe-.*/
-                image_name: ademe
-                name: hub-ademe
-                requires:
-                    - lint-front-ademe
-                    - lint-back-ademe
-                site: ademe
+                        only: /.*/
+                name: no-change-ademe
     canary:
         jobs:
             - hub-canary:
@@ -484,190 +429,25 @@ workflows:
                 - << pipeline.schedule.name >>
     demo:
         jobs:
-            - check-changelog:
-                filters:
-                    branches:
-                        ignore: /.*/
-                name: check-changelog-demo
-                site: demo
-            - lint-changelog:
-                filters:
-                    branches:
-                        ignore: main
-                    tags:
-                        only: /^demo-.*/
-                name: lint-changelog--demo
-                site: demo
-            - build-front-production:
+            - no-change:
                 filters:
                     tags:
-                        only: /^demo-.*/
-                name: build-front-production-demo
-                site: demo
-            - lint-front:
-                filters:
-                    tags:
-                        only: /^demo-.*/
-                name: lint-front-demo
-                requires:
-                    - build-front-production-demo
-                site: demo
-            - build-back:
-                filters:
-                    tags:
-                        only: /^demo-.*/
-                name: build-back-demo
-                site: demo
-            - lint-back:
-                filters:
-                    tags:
-                        only: /^demo-.*/
-                name: lint-back-demo
-                requires:
-                    - build-back-demo
-                site: demo
-            - test-back:
-                filters:
-                    tags:
-                        only: /^demo-.*/
-                name: test-back-demo
-                requires:
-                    - build-back-demo
-                site: demo
-            - hub:
-                filters:
-                    tags:
-                        only: /^demo-.*/
-                image_name: richie-demo
-                name: hub-demo
-                requires:
-                    - lint-front-demo
-                    - lint-back-demo
-                site: demo
+                        only: /.*/
+                name: no-change-demo
     funcampus:
         jobs:
-            - check-changelog:
-                filters:
-                    branches:
-                        ignore: /.*/
-                name: check-changelog-funcampus
-                site: funcampus
-            - lint-changelog:
-                filters:
-                    branches:
-                        ignore: main
-                    tags:
-                        only: /^funcampus-.*/
-                name: lint-changelog--funcampus
-                site: funcampus
-            - build-front-production:
+            - no-change:
                 filters:
                     tags:
-                        only: /^funcampus-.*/
-                name: build-front-production-funcampus
-                site: funcampus
-            - lint-front:
-                filters:
-                    tags:
-                        only: /^funcampus-.*/
-                name: lint-front-funcampus
-                requires:
-                    - build-front-production-funcampus
-                site: funcampus
-            - build-back:
-                filters:
-                    tags:
-                        only: /^funcampus-.*/
-                name: build-back-funcampus
-                site: funcampus
-            - lint-back:
-                filters:
-                    tags:
-                        only: /^funcampus-.*/
-                name: lint-back-funcampus
-                requires:
-                    - build-back-funcampus
-                site: funcampus
-            - test-back:
-                filters:
-                    tags:
-                        only: /^funcampus-.*/
-                name: test-back-funcampus
-                requires:
-                    - build-back-funcampus
-                site: funcampus
-            - hub:
-                filters:
-                    tags:
-                        only: /^funcampus-.*/
-                image_name: funcampus
-                name: hub-funcampus
-                requires:
-                    - lint-front-funcampus
-                    - lint-back-funcampus
-                site: funcampus
+                        only: /.*/
+                name: no-change-funcampus
     funcorporate:
         jobs:
-            - check-changelog:
-                filters:
-                    branches:
-                        ignore: /.*/
-                name: check-changelog-funcorporate
-                site: funcorporate
-            - lint-changelog:
-                filters:
-                    branches:
-                        ignore: main
-                    tags:
-                        only: /^funcorporate-.*/
-                name: lint-changelog--funcorporate
-                site: funcorporate
-            - build-front-production:
+            - no-change:
                 filters:
                     tags:
-                        only: /^funcorporate-.*/
-                name: build-front-production-funcorporate
-                site: funcorporate
-            - lint-front:
-                filters:
-                    tags:
-                        only: /^funcorporate-.*/
-                name: lint-front-funcorporate
-                requires:
-                    - build-front-production-funcorporate
-                site: funcorporate
-            - build-back:
-                filters:
-                    tags:
-                        only: /^funcorporate-.*/
-                name: build-back-funcorporate
-                site: funcorporate
-            - lint-back:
-                filters:
-                    tags:
-                        only: /^funcorporate-.*/
-                name: lint-back-funcorporate
-                requires:
-                    - build-back-funcorporate
-                site: funcorporate
-            - test-back:
-                filters:
-                    tags:
-                        only: /^funcorporate-.*/
-                name: test-back-funcorporate
-                requires:
-                    - build-back-funcorporate
-                site: funcorporate
-            - hub:
-                filters:
-                    tags:
-                        only: /^funcorporate-.*/
-                image_name: funcorporate
-                name: hub-funcorporate
-                requires:
-                    - lint-front-funcorporate
-                    - lint-back-funcorporate
-                site: funcorporate
+                        only: /.*/
+                name: no-change-funcorporate
     funmooc:
         jobs:
             - check-changelog:

--- a/sites/funmooc/src/frontend/js/api/lms/dummy.ts
+++ b/sites/funmooc/src/frontend/js/api/lms/dummy.ts
@@ -2,7 +2,7 @@ import { AuthenticationBackend, LMSBackend } from 'types/commonDataProps';
 import { Maybe, Nullable } from 'types/utils';
 import { User } from 'types/User';
 import { APILms } from 'types/api';
-import { Enrollment, OpenEdXEnrollment } from 'types';
+import { OpenEdXEnrollment } from 'types';
 import { location } from 'utils/indirection/window';
 import { RICHIE_USER_TOKEN } from 'settings';
 import { base64Decode } from 'utils/base64Parser';
@@ -127,7 +127,8 @@ const API = (APIConf: LMSBackend | AuthenticationBackend): APILms => {
           }
           resolve(null);
         }),
-      isEnrolled: async (enrollment: Maybe<Nullable<Enrollment>>) =>
+      // TODO: Use UnknownEnrollment type instead unknown when next version of Richie will released
+      isEnrolled: async (enrollment: Maybe<Nullable<unknown>>) =>
         new Promise((resolve) => resolve(!!(enrollment as OpenEdXEnrollment)?.is_active)),
       set: (url: string, user: User): Promise<boolean> =>
         new Promise((resolve) => {


### PR DESCRIPTION
The job to build canary image currently fails.
https://app.circleci.com/pipelines/github/openfun/fun-richie-site-factory/561/workflows/d1a4c9ba-5bc6-404e-8b17-266121c142d1/jobs/14812

The next version of `richie-education` package rename `Enrollment` type into `UnknownEnrollment`. As we were using this type in an overridden module, `tsc` command raises an error and prevent the frontend to be built. In order to be able to build canary images without requiring to release a new version of Richie, we simply remove the use of the problematic type. As the impacted module is only reserved for development purpose, this workaround looks acceptable.