### PR TITLE
🚑(funmooc) fix malformed dashboard url

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -450,11 +450,66 @@ workflows:
                 name: no-change-funcorporate
     funmooc:
         jobs:
-            - no-change:
+            - check-changelog:
+                filters:
+                    branches:
+                        ignore: main
+                name: check-changelog-funmooc
+                site: funmooc
+            - lint-changelog:
+                filters:
+                    branches:
+                        ignore: main
+                    tags:
+                        only: /^funmooc-.*/
+                name: lint-changelog--funmooc
+                site: funmooc
+            - build-front-production:
                 filters:
                     tags:
-                        only: /.*/
-                name: no-change-funmooc
+                        only: /^funmooc-.*/
+                name: build-front-production-funmooc
+                site: funmooc
+            - lint-front:
+                filters:
+                    tags:
+                        only: /^funmooc-.*/
+                name: lint-front-funmooc
+                requires:
+                    - build-front-production-funmooc
+                site: funmooc
+            - build-back:
+                filters:
+                    tags:
+                        only: /^funmooc-.*/
+                name: build-back-funmooc
+                site: funmooc
+            - lint-back:
+                filters:
+                    tags:
+                        only: /^funmooc-.*/
+                name: lint-back-funmooc
+                requires:
+                    - build-back-funmooc
+                site: funmooc
+            - test-back:
+                filters:
+                    tags:
+                        only: /^funmooc-.*/
+                name: test-back-funmooc
+                requires:
+                    - build-back-funmooc
+                site: funmooc
+            - hub:
+                filters:
+                    tags:
+                        only: /^funmooc-.*/
+                image_name: funmooc
+                name: hub-funmooc
+                requires:
+                    - lint-front-funmooc
+                    - lint-back-funmooc
+                site: funmooc
     site-factory:
         jobs:
             - lint-git:
@@ -462,7 +517,7 @@ workflows:
                     tags:
                         only: /.*/
             - check-configuration:
-                ci_update_options: --ignore-changelog
+                ci_update_options: ""
                 filters:
                     branches:
                         ignore: main

--- a/sites/funmooc/CHANGELOG.md
+++ b/sites/funmooc/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix malformed dashboard url 
+
 ## [1.29.0] - 2024-04-11
 
 ### Added

--- a/sites/funmooc/src/backend/funmooc/settings.py
+++ b/sites/funmooc/src/backend/funmooc/settings.py
@@ -1,6 +1,7 @@
 """
 Django settings for FUN-MOOC project.
 """
+
 import json
 import os
 
@@ -268,7 +269,7 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
     profile_dashboard_urls = {
         "dashboard": {
             "label": _("Dashboard"),
-            "href": _("{base_url:s}/dashboard/"),
+            "href": _("{base_url:s}/dashboard"),
         },
     }
     if (


### PR DESCRIPTION
The default dashboard url is currently malformed. Indeed there is an extra slash at the end 
so the target is currently a 404 page...