### PR TITLE
✨(funmooc) add custom course template for professional training

### DIFF
--- a/sites/funmooc/CHANGELOG.md
+++ b/sites/funmooc/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Add custom course template for professional training
+
 ## [1.31.0] - 2024-05-14
 
 ### Changed

--- a/sites/funmooc/src/backend/base/templates/cms/professional_training_detail.html
+++ b/sites/funmooc/src/backend/base/templates/cms/professional_training_detail.html
@@ -1,0 +1,28 @@
+{% extends "courses/cms/course_detail.html" %}
+{% load cms_tags i18n extra_tags %}
+{% block skills %}
+{% if current_page.publisher_is_draft or not current_page|is_empty_placeholder:"course_skills" %}
+<div class="course-detail__row course-detail__skills" property="about" typeof="Thing">
+  <h2 class="course-detail__title" property="name">{% blocktrans context "course_detail__title" %}Goals{% endblocktrans %}</h2>
+  <div property="description">
+    <p>{% trans "At the end of this training, you will be able to:" %}</p>
+    {% placeholder "course_skills" %}
+  </div>
+</div>
+{% endif %}
+{% endblock skills %}
+
+{% block plan %}
+<div class="course-detail__block course-detail__secondary-group">
+  {% if current_page.publisher_is_draft or not current_page|is_empty_placeholder:"course_plan" %}
+  {% with is_syllabus_property=True %}
+  <section class="course-detail__row course-detail__plan">
+    <h2 class="course-detail__title">{% blocktrans context "course_detail__title" %}Program{% endblocktrans %}</h2>
+    {% placeholder "course_plan" or %}
+    <p class="course-detail__empty">{% trans 'Enter here the detailed program.' %}</p>
+    {% endplaceholder %}
+  </section>
+  {% endwith %}
+  {% endif %}
+</div>
+{% endblock plan %}

--- a/sites/funmooc/src/backend/base/tests/test_template.py
+++ b/sites/funmooc/src/backend/base/tests/test_template.py
@@ -6,13 +6,14 @@ from django.test import TestCase
 from django.utils import translation
 
 import lxml.html  # nosec
-from richie.apps.core.factories import PageFactory
+from richie.apps.core.factories import PageFactory, UserFactory
+from richie.apps.courses.factories import CourseFactory
 
 
-class BaseTemplateTestCase(TestCase):
+class TemplateBaseTestCase(TestCase):
     """Test the base template."""
 
-    def test_base_template_localized_topbar_logo(self):
+    def test_template_base_localized_topbar_logo(self):
         """
         Test that the base template has a localized topbar logo
         for each enabled languages.
@@ -37,3 +38,43 @@ class BaseTemplateTestCase(TestCase):
 
             # Check that the logo file exists in the static folder
             self.assertIsNotNone(finders.find(f"richie/images/{logo_filename}"))
+
+
+class TemplateProfessionalTrainingDetailTestCase(TestCase):
+    """Test the professional training detail template."""
+
+    def test_template_professional_training(self):
+        """A professional training template should exist."""
+        user = UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=user.username, password="password")  # nosec
+
+        page = PageFactory(template="cms/professional_training_detail.html")
+        CourseFactory(extended_object=page)
+        page_url = page.get_absolute_url()
+        url = f"{page_url:s}?edit"
+
+        # The template should extend the `courses/cms/course_detail.html` template
+        with self.assertTemplateUsed("courses/cms/course_detail.html"):
+            response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 200)
+        html = lxml.html.fromstring(str(response.content.decode("utf-8")))
+
+        course_skills = html.cssselect(".course-detail__skills")[0]
+        course_skills_title = course_skills.cssselect("h2")[0]
+        course_skills_description = course_skills.cssselect("p")[0]
+
+        self.assertEqual(course_skills_title.text_content(), "Objectifs")
+        self.assertEqual(
+            course_skills_description.text_content(),
+            "À la fin de cette formation, vous serez capable de :",
+        )
+
+        course_program = html.cssselect(".course-detail__plan")[0]
+        course_program_title = course_program.cssselect("h2")[0]
+        course_program_description = course_program.cssselect("p")[0]
+        self.assertEqual(course_program_title.text_content(), "Programme")
+        self.assertEqual(
+            course_program_description.text_content(),
+            "Détaillez ici le programme de la formation.",
+        )

--- a/sites/funmooc/src/backend/funmooc/settings.py
+++ b/sites/funmooc/src/backend/funmooc/settings.py
@@ -401,6 +401,11 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
         },
     }
 
+    # Django CMS Page Templates
+    CMS_TEMPLATES_OVERRIDES = (
+        ("cms/professional_training_detail.html", _("Professional training page")),
+    )
+
     MIDDLEWARE = (
         "richie.apps.core.cache.LimitBrowserCacheTTLHeaders",
         "cms.middleware.utils.ApphookReloadMiddleware",
@@ -987,6 +992,12 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
         return [(language, _(name)) for language, name in global_settings.LANGUAGES] + [
             ("ps", _("Pashto"))
         ]
+
+    @classmethod
+    def pre_setup(cls):
+        """Pre setup configuration."""
+
+        cls.CMS_TEMPLATES = cls.CMS_TEMPLATES_OVERRIDES + cls.CMS_TEMPLATES
 
     @classmethod
     def post_setup(cls):

--- a/sites/funmooc/src/backend/locale/fr/LC_MESSAGES/django.po
+++ b/sites/funmooc/src/backend/locale/fr/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-05-06 14:42+0200\n"
+"POT-Creation-Date: 2024-05-15 17:25+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -20,6 +20,24 @@ msgstr ""
 #: base/admin.py:33
 msgid "Unsorted uploads are not allowed."
 msgstr "Les téléchargements non classés sont interdits"
+
+#: base/templates/cms/professional_training_detail.html:6
+msgctxt "course_detail__title"
+msgid "Goals"
+msgstr "Objectifs"
+
+#: base/templates/cms/professional_training_detail.html:8
+msgid "At the end of this training, you will be able to:"
+msgstr "À la fin de cette formation, vous serez capable de :"
+
+#: base/templates/cms/professional_training_detail.html:20
+msgctxt "course_detail__title"
+msgid "Program"
+msgstr "Programme"
+
+#: base/templates/cms/professional_training_detail.html:22
+msgid "Enter here the detailed program."
+msgstr "Détaillez ici le programme de la formation."
 
 #: funmooc/settings.py:125
 msgid "Availability"
@@ -69,63 +87,67 @@ msgstr ""
 msgid "Teaser"
 msgstr "Accroche"
 
-#: funmooc/settings.py:482 funmooc/settings.py:484
+#: funmooc/settings.py:406
+msgid "Professional training page"
+msgstr "Page de formation professionnelle"
+
+#: funmooc/settings.py:487 funmooc/settings.py:489
 msgid "New courses"
 msgstr "Nouveaux cours"
 
-#: funmooc/settings.py:494
+#: funmooc/settings.py:499
 msgid "Types"
 msgstr "Types"
 
-#: funmooc/settings.py:505
+#: funmooc/settings.py:510
 msgid "Subjects"
 msgstr "Thématiques"
 
-#: funmooc/settings.py:516
+#: funmooc/settings.py:521
 msgid "Collections"
 msgstr "Collections"
 
-#: funmooc/settings.py:527
+#: funmooc/settings.py:532
 msgid "Organizations"
 msgstr "Établissements"
 
-#: funmooc/settings.py:538
+#: funmooc/settings.py:543
 msgid "Contributors"
 msgstr "Contributeurs"
 
-#: funmooc/settings.py:549
+#: funmooc/settings.py:554
 msgid "Licences"
 msgstr "Licences"
 
-#: funmooc/settings.py:566
+#: funmooc/settings.py:571
 msgid "Weekly pace"
 msgstr "Rythme hebdomadaire"
 
-#: funmooc/settings.py:570
+#: funmooc/settings.py:575
 msgid "Self-paced"
 msgstr "À son rythme"
 
-#: funmooc/settings.py:571
+#: funmooc/settings.py:576
 msgid "Less than one hour"
 msgstr "Moins d'une heure"
 
-#: funmooc/settings.py:572
+#: funmooc/settings.py:577
 msgid "One to two hours"
 msgstr "Une à deux heures"
 
-#: funmooc/settings.py:573
+#: funmooc/settings.py:578
 msgid "More than two hours"
 msgstr "Plus de deux heures"
 
-#: funmooc/settings.py:599 funmooc/settings.py:614
+#: funmooc/settings.py:604 funmooc/settings.py:619
 msgid "English"
 msgstr "Anglais"
 
-#: funmooc/settings.py:599 funmooc/settings.py:622
+#: funmooc/settings.py:604 funmooc/settings.py:627
 msgid "French"
 msgstr "Français"
 
-#: funmooc/settings.py:988
+#: funmooc/settings.py:993
 msgid "Pashto"
 msgstr "Pachtoun"
 


### PR DESCRIPTION
We are preparing professional training on FUN Mooc and we would like to use more relevant jargon for this kind of course so we decide to create a custom course page template which extends to the course detail template.

<img width="591" alt="image" src="https://github.com/openfun/fun-richie-site-factory/assets/9265241/ea180e6d-ba2c-41cc-a173-3bc70bb6b329">
<img width="793" alt="image" src="https://github.com/openfun/fun-richie-site-factory/assets/9265241/cd0f88b0-0864-4fc4-a56c-8213b68ce0e5">