### PR TITLE
🔧(funmooc) add missing CSRF_TRUSTED_ORIGINS settings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -398,66 +398,11 @@ version: 2.1
 workflows:
     ademe:
         jobs:
-            - check-changelog:
-                filters:
-                    branches:
-                        ignore: /.*/
-                name: check-changelog-ademe
-                site: ademe
-            - lint-changelog:
-                filters:
-                    branches:
-                        ignore: main
-                    tags:
-                        only: /^ademe-.*/
-                name: lint-changelog--ademe
-                site: ademe
-            - build-front-production:
+            - no-change:
                 filters:
                     tags:
-                        only: /^ademe-.*/
-                name: build-front-production-ademe
-                site: ademe
-            - lint-front:
-                filters:
-                    tags:
-                        only: /^ademe-.*/
-                name: lint-front-ademe
-                requires:
-                    - build-front-production-ademe
-                site: ademe
-            - build-back:
-                filters:
-                    tags:
-                        only: /^ademe-.*/
-                name: build-back-ademe
-                site: ademe
-            - lint-back:
-                filters:
-                    tags:
-                        only: /^ademe-.*/
-                name: lint-back-ademe
-                requires:
-                    - build-back-ademe
-                site: ademe
-            - test-back:
-                filters:
-                    tags:
-                        only: /^ademe-.*/
-                name: test-back-ademe
-                requires:
-                    - build-back-ademe
-                site: ademe
-            - hub:
-                filters:
-                    tags:
-                        only: /^ademe-.*/
-                image_name: ademe
-                name: hub-ademe
-                requires:
-                    - lint-front-ademe
-                    - lint-back-ademe
-                site: ademe
+                        only: /.*/
+                name: no-change-ademe
     canary:
         jobs:
             - hub-canary:
@@ -486,190 +431,25 @@ workflows:
                 - << pipeline.schedule.name >>
     demo:
         jobs:
-            - check-changelog:
-                filters:
-                    branches:
-                        ignore: /.*/
-                name: check-changelog-demo
-                site: demo
-            - lint-changelog:
-                filters:
-                    branches:
-                        ignore: main
-                    tags:
-                        only: /^demo-.*/
-                name: lint-changelog--demo
-                site: demo
-            - build-front-production:
+            - no-change:
                 filters:
                     tags:
-                        only: /^demo-.*/
-                name: build-front-production-demo
-                site: demo
-            - lint-front:
-                filters:
-                    tags:
-                        only: /^demo-.*/
-                name: lint-front-demo
-                requires:
-                    - build-front-production-demo
-                site: demo
-            - build-back:
-                filters:
-                    tags:
-                        only: /^demo-.*/
-                name: build-back-demo
-                site: demo
-            - lint-back:
-                filters:
-                    tags:
-                        only: /^demo-.*/
-                name: lint-back-demo
-                requires:
-                    - build-back-demo
-                site: demo
-            - test-back:
-                filters:
-                    tags:
-                        only: /^demo-.*/
-                name: test-back-demo
-                requires:
-                    - build-back-demo
-                site: demo
-            - hub:
-                filters:
-                    tags:
-                        only: /^demo-.*/
-                image_name: richie-demo
-                name: hub-demo
-                requires:
-                    - lint-front-demo
-                    - lint-back-demo
-                site: demo
+                        only: /.*/
+                name: no-change-demo
     funcampus:
         jobs:
-            - check-changelog:
-                filters:
-                    branches:
-                        ignore: /.*/
-                name: check-changelog-funcampus
-                site: funcampus
-            - lint-changelog:
-                filters:
-                    branches:
-                        ignore: main
-                    tags:
-                        only: /^funcampus-.*/
-                name: lint-changelog--funcampus
-                site: funcampus
-            - build-front-production:
+            - no-change:
                 filters:
                     tags:
-                        only: /^funcampus-.*/
-                name: build-front-production-funcampus
-                site: funcampus
-            - lint-front:
-                filters:
-                    tags:
-                        only: /^funcampus-.*/
-                name: lint-front-funcampus
-                requires:
-                    - build-front-production-funcampus
-                site: funcampus
-            - build-back:
-                filters:
-                    tags:
-                        only: /^funcampus-.*/
-                name: build-back-funcampus
-                site: funcampus
-            - lint-back:
-                filters:
-                    tags:
-                        only: /^funcampus-.*/
-                name: lint-back-funcampus
-                requires:
-                    - build-back-funcampus
-                site: funcampus
-            - test-back:
-                filters:
-                    tags:
-                        only: /^funcampus-.*/
-                name: test-back-funcampus
-                requires:
-                    - build-back-funcampus
-                site: funcampus
-            - hub:
-                filters:
-                    tags:
-                        only: /^funcampus-.*/
-                image_name: funcampus
-                name: hub-funcampus
-                requires:
-                    - lint-front-funcampus
-                    - lint-back-funcampus
-                site: funcampus
+                        only: /.*/
+                name: no-change-funcampus
     funcorporate:
         jobs:
-            - check-changelog:
-                filters:
-                    branches:
-                        ignore: /.*/
-                name: check-changelog-funcorporate
-                site: funcorporate
-            - lint-changelog:
-                filters:
-                    branches:
-                        ignore: main
-                    tags:
-                        only: /^funcorporate-.*/
-                name: lint-changelog--funcorporate
-                site: funcorporate
-            - build-front-production:
+            - no-change:
                 filters:
                     tags:
-                        only: /^funcorporate-.*/
-                name: build-front-production-funcorporate
-                site: funcorporate
-            - lint-front:
-                filters:
-                    tags:
-                        only: /^funcorporate-.*/
-                name: lint-front-funcorporate
-                requires:
-                    - build-front-production-funcorporate
-                site: funcorporate
-            - build-back:
-                filters:
-                    tags:
-                        only: /^funcorporate-.*/
-                name: build-back-funcorporate
-                site: funcorporate
-            - lint-back:
-                filters:
-                    tags:
-                        only: /^funcorporate-.*/
-                name: lint-back-funcorporate
-                requires:
-                    - build-back-funcorporate
-                site: funcorporate
-            - test-back:
-                filters:
-                    tags:
-                        only: /^funcorporate-.*/
-                name: test-back-funcorporate
-                requires:
-                    - build-back-funcorporate
-                site: funcorporate
-            - hub:
-                filters:
-                    tags:
-                        only: /^funcorporate-.*/
-                image_name: funcorporate
-                name: hub-funcorporate
-                requires:
-                    - lint-front-funcorporate
-                    - lint-back-funcorporate
-                site: funcorporate
+                        only: /.*/
+                name: no-change-funcorporate
     funmooc:
         jobs:
             - check-changelog:
@@ -739,7 +519,7 @@ workflows:
                     tags:
                         only: /.*/
             - check-configuration:
-                ci_update_options: --ignore-changelog
+                ci_update_options: ""
                 filters:
                     branches:
                         ignore: main

--- a/sites/funmooc/CHANGELOG.md
+++ b/sites/funmooc/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Add missing `CSRF_TRUSTED_ORIGINS` setting in Production configuration
+
 ## [1.32.0] - 2024-05-22
 
 ### Added

--- a/sites/funmooc/CHANGELOG.md
+++ b/sites/funmooc/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.32.1] - 2024-05-23
+
 ### Fixed
 
 - Add missing `CSRF_TRUSTED_ORIGINS` setting in Production configuration
@@ -702,7 +704,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Static and media files are stored in AWS S3 buckets and distributed _via_
   Amazon CloudFront
 
-[unreleased]: https://github.com/openfun/fun-richie-site-factory/compare/funmooc-1.32.0...HEAD
+[unreleased]: https://github.com/openfun/fun-richie-site-factory/compare/funmooc-1.32.1...HEAD
+[1.32.1]: https://github.com/openfun/fun-richie-site-factory/compare/funmooc-1.32.0...funmooc-1.32.1
 [1.32.0]: https://github.com/openfun/fun-richie-site-factory/compare/funmooc-1.31.0...funmooc-1.32.0
 [1.31.0]: https://github.com/openfun/fun-richie-site-factory/compare/funmooc-1.30.0...funmooc-1.31.0
 [1.30.0]: https://github.com/openfun/fun-richie-site-factory/compare/funmooc-1.29.1...funmooc-1.30.0

--- a/sites/funmooc/src/backend/funmooc/__init__.py
+++ b/sites/funmooc/src/backend/funmooc/__init__.py
@@ -1,3 +1,3 @@
 """funmooc application"""
 
-__version__ = "1.32.0"
+__version__ = "1.32.1"

--- a/sites/funmooc/src/backend/funmooc/settings.py
+++ b/sites/funmooc/src/backend/funmooc/settings.py
@@ -1115,6 +1115,8 @@ class Production(Base):
     # Security
     SECRET_KEY = values.SecretValue()
     CSRF_COOKIE_SECURE = True
+    CSRF_TRUSTED_ORIGINS = values.ListValue([])
+    CSRF_COOKIE_DOMAIN = values.Value(None)
     SECURE_BROWSER_XSS_FILTER = True
     SECURE_CONTENT_TYPE_NOSNIFF = True
     SESSION_COOKIE_SECURE = True

--- a/sites/funmooc/src/frontend/package.json
+++ b/sites/funmooc/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "funmooc",
-  "version": "1.32.0",
+  "version": "1.32.1",
   "description": "Richie-powered CMS for fun-mooc.fr",
   "scripts": {
     "build-sass": "sass scss/_main.scss ../backend/base/static/richie/css/main.css --load-path=node_modules",


### PR DESCRIPTION
With Django 4, the setting `CSRF_TRUSTED_ORIGINS` may be required. So we add it
for the production configuration.

Then release a patch version of FUN Mooc.