### PR TITLE
🍱(funmooc) Update 'funmooc' site integration to move up main menu and move down the search bar

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -431,66 +431,11 @@ workflows:
                 - << pipeline.schedule.name >>
     demo:
         jobs:
-            - check-changelog:
-                filters:
-                    branches:
-                        ignore: /.*/
-                name: check-changelog-demo
-                site: demo
-            - lint-changelog:
-                filters:
-                    branches:
-                        ignore: main
-                    tags:
-                        only: /^demo-.*/
-                name: lint-changelog--demo
-                site: demo
-            - build-front-production:
+            - no-change:
                 filters:
                     tags:
-                        only: /^demo-.*/
-                name: build-front-production-demo
-                site: demo
-            - lint-front:
-                filters:
-                    tags:
-                        only: /^demo-.*/
-                name: lint-front-demo
-                requires:
-                    - build-front-production-demo
-                site: demo
-            - build-back:
-                filters:
-                    tags:
-                        only: /^demo-.*/
-                name: build-back-demo
-                site: demo
-            - lint-back:
-                filters:
-                    tags:
-                        only: /^demo-.*/
-                name: lint-back-demo
-                requires:
-                    - build-back-demo
-                site: demo
-            - test-back:
-                filters:
-                    tags:
-                        only: /^demo-.*/
-                name: test-back-demo
-                requires:
-                    - build-back-demo
-                site: demo
-            - hub:
-                filters:
-                    tags:
-                        only: /^demo-.*/
-                image_name: richie-demo
-                name: hub-demo
-                requires:
-                    - lint-front-demo
-                    - lint-back-demo
-                site: demo
+                        only: /.*/
+                name: no-change-demo
     funcampus:
         jobs:
             - no-change:
@@ -507,11 +452,66 @@ workflows:
                 name: no-change-funcorporate
     funmooc:
         jobs:
-            - no-change:
+            - check-changelog:
+                filters:
+                    branches:
+                        ignore: main
+                name: check-changelog-funmooc
+                site: funmooc
+            - lint-changelog:
+                filters:
+                    branches:
+                        ignore: main
+                    tags:
+                        only: /^funmooc-.*/
+                name: lint-changelog--funmooc
+                site: funmooc
+            - build-front-production:
                 filters:
                     tags:
-                        only: /.*/
-                name: no-change-funmooc
+                        only: /^funmooc-.*/
+                name: build-front-production-funmooc
+                site: funmooc
+            - lint-front:
+                filters:
+                    tags:
+                        only: /^funmooc-.*/
+                name: lint-front-funmooc
+                requires:
+                    - build-front-production-funmooc
+                site: funmooc
+            - build-back:
+                filters:
+                    tags:
+                        only: /^funmooc-.*/
+                name: build-back-funmooc
+                site: funmooc
+            - lint-back:
+                filters:
+                    tags:
+                        only: /^funmooc-.*/
+                name: lint-back-funmooc
+                requires:
+                    - build-back-funmooc
+                site: funmooc
+            - test-back:
+                filters:
+                    tags:
+                        only: /^funmooc-.*/
+                name: test-back-funmooc
+                requires:
+                    - build-back-funmooc
+                site: funmooc
+            - hub:
+                filters:
+                    tags:
+                        only: /^funmooc-.*/
+                image_name: funmooc
+                name: hub-funmooc
+                requires:
+                    - lint-front-funmooc
+                    - lint-back-funmooc
+                site: funmooc
     site-factory:
         jobs:
             - lint-git:
@@ -519,7 +519,7 @@ workflows:
                     tags:
                         only: /.*/
             - check-configuration:
-                ci_update_options: --ignore-changelog
+                ci_update_options: ""
                 filters:
                     branches:
                         ignore: main

--- a/sites/funmooc/CHANGELOG.md
+++ b/sites/funmooc/CHANGELOG.md
@@ -8,6 +8,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Update 'funmooc' site integration to move up main menu and move down the
+  search bar
+
 ## [1.35.2] - 2024-09-23
 
 ### Fixed

--- a/sites/funmooc/src/backend/templates/courses/cms/course_detail.html
+++ b/sites/funmooc/src/backend/templates/courses/cms/course_detail.html
@@ -1,0 +1,10 @@
+{% extends "courses/cms/course_detail.html" %}
+{% load cms_tags %}
+
+{% block breadcrumbs %}
+    <div class="breadcrumbs__wrapper">
+        {% include "menu/breadcrumbs.html" %}
+        <div class="breadcrumbs__aside richie-react richie-react--root-search-suggest-field"
+            data-props='{"courseSearchPageUrl": "{% page_url 'courses' %}"}'></div>
+    </div>
+{% endblock breadcrumbs %}

--- a/sites/funmooc/src/backend/templates/richie/base.html
+++ b/sites/funmooc/src/backend/templates/richie/base.html
@@ -1,5 +1,5 @@
 {% extends "richie/base.html" %}
-{% load cms_tags static i18n %}
+{% load cms_tags menu_tags static i18n %}
 
 {% block meta_favicons %}
 <link rel="apple-touch-icon" sizes="180x180" href="{% static 'richie/favicon/apple-touch-icon.png' %}">
@@ -13,16 +13,59 @@
 <meta name="theme-color" content="#ffffff">
 {% endblock meta_favicons %}
 
-{% block topbar_contact %}
-<li class="topbar__item topbar__item--cta">
-    <a href="{% page_url 'help' %}">{% trans "FAQ" %}</a>
-</li>
-{% endblock topbar_contact %}
+{% block body_header %}
+<div id="site-header">
+    <div class="topbar {% block topbar_classes %}{% endblock topbar_classes %}" id="main-menu">
+        <div class="topbar__container">
+            <header class="topbar__header">
+                <div class="topbar__brand">
+                    <a href="/" title="{% trans "Go to homepage" %}" rel="home" accesskey="h">
+                    {% block branding_topbar %}
+                        {% get_current_language as LANGUAGE_CODE %}
+                        <img src="{% get_static_prefix %}richie/images/logo-{{LANGUAGE_CODE}}.svg" class="topbar__logo" alt="{{ SITE.name }}">
+                    {% endblock branding_topbar %}
+                    </a>
 
-{% block branding_topbar %}
-    {% get_current_language as LANGUAGE_CODE %}
-    <img src="{% get_static_prefix %}richie/images/logo-{{LANGUAGE_CODE}}.svg" class="topbar__logo" alt="{{ SITE.name }}">
-{% endblock branding_topbar %}
+                    <button
+                        class="topbar__hamburger"
+                        data-target="main-menu"
+                        aria-label="{% trans "Menu" %}"
+                        aria-expanded="false"
+                    >&#8801;</button>
+                </div>
+
+                <nav class="topbar__menu">
+                    <ul class="topbar__list">
+                        {% show_menu 0 100 0 0 "menu/header_menu.html" %}
+                    </ul>
+                </nav>
+
+                <div class="topbar__menu topbar__menu--aside">
+                    {% block topbar_searchbar %}{% endblock topbar_searchbar %}
+                    <ul class="topbar__list topbar__list--controls">
+                        {% block userlogin %}
+                            {% if AUTHENTICATION %}
+                                <li class="topbar__item topbar__item--login richie-react richie-react--user-login" data-props='{"profileUrls": {{ AUTHENTICATION.profile_urls }}}'></li>
+                            {% endif %}
+                        {% endblock userlogin %}
+                        {% block topbar_contact %}{% endblock topbar_contact %}
+                    </ul>
+
+                    {% language_chooser "menu/language_menu.html" %}
+                </div>
+            </header>
+        </div>
+    </div>
+</div>
+{% endblock body_header %}
+
+{% block breadcrumbs %}
+    <div class="breadcrumbs__wrapper">
+        {% include "menu/breadcrumbs.html" %}
+        <div class="breadcrumbs__aside richie-react richie-react--root-search-suggest-field"
+            data-props='{"courseSearchPageUrl": "{% page_url 'courses' %}"}'></div>
+    </div>
+{% endblock breadcrumbs %}
 
 {% block body_footer_title %}{% endblock body_footer_title %}
 

--- a/sites/funmooc/src/frontend/scss/_main.scss
+++ b/sites/funmooc/src/frontend/scss/_main.scss
@@ -49,10 +49,14 @@
 // Shared object styles
 @import 'richie-education/scss/objects/index';
 
+// Shared object overrides
+@import './objects/breadcrumbs';
+
 // Page component styles
 @import 'richie-education/scss/components/index';
 
 // Page component overrides
+@import './components/header';
 @import './components/subheader';
 @import './components/templates/courses/cms/homepage';
 @import './components/templates/richie/large_banner/large_banner';

--- a/sites/funmooc/src/frontend/scss/components/_header.scss
+++ b/sites/funmooc/src/frontend/scss/components/_header.scss
@@ -1,0 +1,101 @@
+.topbar {
+  &__container {
+    max-width: 100%;
+
+    @include media-breakpoint-up(xl) {
+      @include make-container();
+      @include make-container-max-widths();
+    }
+  }
+
+  &__brand {
+    @include media-breakpoint-up($r-topbar-breakpoint) {
+      margin-right: 0;
+    }
+    @include media-breakpoint-up(xl) {
+      margin-right: 0;
+    }
+    @include media-breakpoint-up(xxl) {
+      margin-right: 0;
+    }
+  }
+
+  &__list {
+    &--controls {
+      @include media-breakpoint-up($r-topbar-breakpoint) {
+        align-items: flex-end;
+      }
+
+      .topbar__item + .topbar__item {
+        @include media-breakpoint-up($r-topbar-breakpoint) {
+          margin-left: 0;
+        }
+        @include media-breakpoint-up(xl) {
+          margin-left: 0.5rem;
+        }
+      }
+    }
+  }
+
+  &__menu {
+    @include sv-flex(1, 0, auto);
+    order: 2;
+    font-family: $r-font-family-montserrat;
+    font-weight: $font-weight-boldest;
+
+    @include media-breakpoint-only(lg) {
+      font-size: 0.7rem;
+    }
+
+    .topbar__list {
+      justify-content: flex-end;
+    }
+
+    &--aside {
+      @include sv-flex(0, 0, auto);
+      order: 3;
+      font-family: $r-font-family-montserrat;
+      font-weight: $font-weight-boldest;
+
+      .selector__button {
+        font-size: inherit;
+      }
+      .selector__list__link {
+        font-size: inherit;
+        font-weight: normal;
+      }
+    }
+  }
+
+  &__item {
+    & > a {
+      @include media-breakpoint-up($r-topbar-breakpoint) {
+        padding-bottom: 2rem;
+        align-items: flex-end;
+      }
+      @include media-breakpoint-only(lg) {
+        padding-left: 0.7rem;
+        padding-right: 0.7rem;
+      }
+    }
+
+    &--login {
+      @include media-breakpoint-up($r-topbar-breakpoint) {
+        padding-bottom: 1.2rem;
+        align-items: flex-end;
+      }
+    }
+  }
+
+  .richie-react--language-selector {
+    align-items: flex-end;
+
+    @include media-breakpoint-up($r-topbar-breakpoint) {
+      padding-bottom: 1.2rem;
+    }
+  }
+
+  .user-login__btn--sign-up {
+    display: none;
+  }
+}

--- a/sites/funmooc/src/frontend/scss/extras/settings/_variables.scss
+++ b/sites/funmooc/src/frontend/scss/extras/settings/_variables.scss
@@ -11,8 +11,8 @@ $extra-font-size: 4.5rem;
 $r-topbar-height: 8.9375rem;
 
 // Header logo width is required for SVG logos
-$r-topbar-logo-width-sm: 12.125rem;
-$r-topbar-logo-width-lg: 12.125rem;
+$r-topbar-logo-width-sm: 11.125rem;
+$r-topbar-logo-width-lg: 11.125rem;
 
 // Header logo width is required for SVG logos
 $r-footer-logo-width-sm: 12.125rem;

--- a/sites/funmooc/src/frontend/scss/objects/_breadcrumbs.scss
+++ b/sites/funmooc/src/frontend/scss/objects/_breadcrumbs.scss
@@ -1,0 +1,53 @@
+
+.breadcrumbs__wrapper {
+  @include make-container();
+  @include make-container-max-widths();
+  padding: 0;
+  display: flex;
+
+  @include media-breakpoint-down(sm) {
+    flex-wrap: wrap;
+  }
+
+  .breadcrumbs {
+    @include sv-flex(1, 0, 65%);
+
+    @include media-breakpoint-down(sm) {
+      @include sv-flex(1, 0, 100%);
+    }
+  }
+
+  .breadcrumbs__aside {
+    @include sv-flex(1, 0, 35%);
+    display: flex;
+    align-items: center;
+
+    @include media-breakpoint-down(sm) {
+      @include sv-flex(1, 0, 100%);
+      padding-left: 1rem;
+      padding-bottom: 1rem;
+    }
+
+    .react-autosuggest__container {
+      width: 100%;
+      margin-bottom: 0;
+
+      @include media-breakpoint-down(sm) {
+        padding-right: 1rem;
+      }
+    }
+
+    .react-autosuggest__input {
+      color: r-color('white');
+      background-color: transparent;
+
+      &::placeholder {
+        color: r-color('white');
+      }
+
+      &--focused::placeholder {
+        color: r-color('white');
+      }
+    }
+  }
+}


### PR DESCRIPTION
Purpose of this PR is to change header structure so the main menu are moved up aside brand logo and search bar have been moved down aside breadcrumbs.

- Since in the demo the main menu is too large for the available space, the signup button has been hided from CSS but frontend developer may prefer to do this at the richie-react login module level;
- Base template disable the `topbar_contact` block content since funmooc was using it for the FAQ link which will be moved somewhere else further;
- Breadcrumb part has been changed to include the search bar aside;
- Sass changes on different components and objects have been made to perform the header and breadcrumbs adjustments;
- Also some space adjustments have been made on header for` >1024px`,`<xl` breakpoints to  ensure the main menu will fit;

## Sample screenshots

### Homepage, unlogged

Header without search bar (since it is still included in intro block)

![homepage](https://github.com/user-attachments/assets/0caba193-87a6-4e83-8bf9-0cf14ee6c6f6)

### Internal page

In various breakpoints

![internal_page_medium](https://github.com/user-attachments/assets/f51d140a-5231-4de7-99c0-0bfbd9949494)

---

![internal_page_large](https://github.com/user-attachments/assets/038349ee-228e-4285-a1da-6b2840724707)

---

![internal_page_xl](https://github.com/user-attachments/assets/abcb602a-98b4-42b3-941b-677c1daf040e)

# Course list

This page has been left unchanged.

![course_list](https://github.com/user-attachments/assets/ceb4ac3c-adfd-49bd-9e4e-c83c7806a137)


