### PR TITLE
🔧(docker) fix docker build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -398,11 +398,66 @@ version: 2.1
 workflows:
     ademe:
         jobs:
-            - no-change:
+            - check-changelog:
+                filters:
+                    branches:
+                        ignore: /.*/
+                name: check-changelog-ademe
+                site: ademe
+            - lint-changelog:
+                filters:
+                    branches:
+                        ignore: main
+                    tags:
+                        only: /^ademe-.*/
+                name: lint-changelog--ademe
+                site: ademe
+            - build-front-production:
                 filters:
                     tags:
-                        only: /.*/
-                name: no-change-ademe
+                        only: /^ademe-.*/
+                name: build-front-production-ademe
+                site: ademe
+            - lint-front:
+                filters:
+                    tags:
+                        only: /^ademe-.*/
+                name: lint-front-ademe
+                requires:
+                    - build-front-production-ademe
+                site: ademe
+            - build-back:
+                filters:
+                    tags:
+                        only: /^ademe-.*/
+                name: build-back-ademe
+                site: ademe
+            - lint-back:
+                filters:
+                    tags:
+                        only: /^ademe-.*/
+                name: lint-back-ademe
+                requires:
+                    - build-back-ademe
+                site: ademe
+            - test-back:
+                filters:
+                    tags:
+                        only: /^ademe-.*/
+                name: test-back-ademe
+                requires:
+                    - build-back-ademe
+                site: ademe
+            - hub:
+                filters:
+                    tags:
+                        only: /^ademe-.*/
+                image_name: ademe
+                name: hub-ademe
+                requires:
+                    - lint-front-ademe
+                    - lint-back-ademe
+                site: ademe
     canary:
         jobs:
             - hub-canary:
@@ -431,11 +486,66 @@ workflows:
                 - << pipeline.schedule.name >>
     demo:
         jobs:
-            - no-change:
+            - check-changelog:
+                filters:
+                    branches:
+                        ignore: /.*/
+                name: check-changelog-demo
+                site: demo
+            - lint-changelog:
+                filters:
+                    branches:
+                        ignore: main
+                    tags:
+                        only: /^demo-.*/
+                name: lint-changelog--demo
+                site: demo
+            - build-front-production:
                 filters:
                     tags:
-                        only: /.*/
-                name: no-change-demo
+                        only: /^demo-.*/
+                name: build-front-production-demo
+                site: demo
+            - lint-front:
+                filters:
+                    tags:
+                        only: /^demo-.*/
+                name: lint-front-demo
+                requires:
+                    - build-front-production-demo
+                site: demo
+            - build-back:
+                filters:
+                    tags:
+                        only: /^demo-.*/
+                name: build-back-demo
+                site: demo
+            - lint-back:
+                filters:
+                    tags:
+                        only: /^demo-.*/
+                name: lint-back-demo
+                requires:
+                    - build-back-demo
+                site: demo
+            - test-back:
+                filters:
+                    tags:
+                        only: /^demo-.*/
+                name: test-back-demo
+                requires:
+                    - build-back-demo
+                site: demo
+            - hub:
+                filters:
+                    tags:
+                        only: /^demo-.*/
+                image_name: richie-demo
+                name: hub-demo
+                requires:
+                    - lint-front-demo
+                    - lint-back-demo
+                site: demo
     funcampus:
         jobs:
             - check-changelog:
@@ -500,18 +610,128 @@ workflows:
                 site: funcampus
     funcorporate:
         jobs:
-            - no-change:
+            - check-changelog:
+                filters:
+                    branches:
+                        ignore: /.*/
+                name: check-changelog-funcorporate
+                site: funcorporate
+            - lint-changelog:
+                filters:
+                    branches:
+                        ignore: main
+                    tags:
+                        only: /^funcorporate-.*/
+                name: lint-changelog--funcorporate
+                site: funcorporate
+            - build-front-production:
                 filters:
                     tags:
-                        only: /.*/
-                name: no-change-funcorporate
+                        only: /^funcorporate-.*/
+                name: build-front-production-funcorporate
+                site: funcorporate
+            - lint-front:
+                filters:
+                    tags:
+                        only: /^funcorporate-.*/
+                name: lint-front-funcorporate
+                requires:
+                    - build-front-production-funcorporate
+                site: funcorporate
+            - build-back:
+                filters:
+                    tags:
+                        only: /^funcorporate-.*/
+                name: build-back-funcorporate
+                site: funcorporate
+            - lint-back:
+                filters:
+                    tags:
+                        only: /^funcorporate-.*/
+                name: lint-back-funcorporate
+                requires:
+                    - build-back-funcorporate
+                site: funcorporate
+            - test-back:
+                filters:
+                    tags:
+                        only: /^funcorporate-.*/
+                name: test-back-funcorporate
+                requires:
+                    - build-back-funcorporate
+                site: funcorporate
+            - hub:
+                filters:
+                    tags:
+                        only: /^funcorporate-.*/
+                image_name: funcorporate
+                name: hub-funcorporate
+                requires:
+                    - lint-front-funcorporate
+                    - lint-back-funcorporate
+                site: funcorporate
     funmooc:
         jobs:
-            - no-change:
+            - check-changelog:
+                filters:
+                    branches:
+                        ignore: /.*/
+                name: check-changelog-funmooc
+                site: funmooc
+            - lint-changelog:
+                filters:
+                    branches:
+                        ignore: main
+                    tags:
+                        only: /^funmooc-.*/
+                name: lint-changelog--funmooc
+                site: funmooc
+            - build-front-production:
                 filters:
                     tags:
-                        only: /.*/
-                name: no-change-funmooc
+                        only: /^funmooc-.*/
+                name: build-front-production-funmooc
+                site: funmooc
+            - lint-front:
+                filters:
+                    tags:
+                        only: /^funmooc-.*/
+                name: lint-front-funmooc
+                requires:
+                    - build-front-production-funmooc
+                site: funmooc
+            - build-back:
+                filters:
+                    tags:
+                        only: /^funmooc-.*/
+                name: build-back-funmooc
+                site: funmooc
+            - lint-back:
+                filters:
+                    tags:
+                        only: /^funmooc-.*/
+                name: lint-back-funmooc
+                requires:
+                    - build-back-funmooc
+                site: funmooc
+            - test-back:
+                filters:
+                    tags:
+                        only: /^funmooc-.*/
+                name: test-back-funmooc
+                requires:
+                    - build-back-funmooc
+                site: funmooc
+            - hub:
+                filters:
+                    tags:
+                        only: /^funmooc-.*/
+                image_name: funmooc
+                name: hub-funmooc
+                requires:
+                    - lint-front-funmooc
+                    - lint-back-funmooc
+                site: funmooc
     site-factory:
         jobs:
             - lint-git:


### PR DESCRIPTION
Since an update of Docker, the build failed during python dependencies setup. It
 appears there is a missing `&&` to chain two pip installs.

We also take opportunity of this change to fix the warning `FromAsCasing`.