### PR TITLE
🔧(all) migrate to new STORAGES settings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -401,7 +401,7 @@ workflows:
             - check-changelog:
                 filters:
                     branches:
-                        ignore: /.*/
+                        ignore: main
                 name: check-changelog-ademe
                 site: ademe
             - lint-changelog:
@@ -489,7 +489,7 @@ workflows:
             - check-changelog:
                 filters:
                     branches:
-                        ignore: /.*/
+                        ignore: main
                 name: check-changelog-demo
                 site: demo
             - lint-changelog:
@@ -551,7 +551,7 @@ workflows:
             - check-changelog:
                 filters:
                     branches:
-                        ignore: /.*/
+                        ignore: main
                 name: check-changelog-funcampus
                 site: funcampus
             - lint-changelog:
@@ -613,7 +613,7 @@ workflows:
             - check-changelog:
                 filters:
                     branches:
-                        ignore: /.*/
+                        ignore: main
                 name: check-changelog-funcorporate
                 site: funcorporate
             - lint-changelog:
@@ -672,66 +672,11 @@ workflows:
                 site: funcorporate
     funmooc:
         jobs:
-            - check-changelog:
-                filters:
-                    branches:
-                        ignore: /.*/
-                name: check-changelog-funmooc
-                site: funmooc
-            - lint-changelog:
-                filters:
-                    branches:
-                        ignore: main
-                    tags:
-                        only: /^funmooc-.*/
-                name: lint-changelog--funmooc
-                site: funmooc
-            - build-front-production:
+            - no-change:
                 filters:
                     tags:
-                        only: /^funmooc-.*/
-                name: build-front-production-funmooc
-                site: funmooc
-            - lint-front:
-                filters:
-                    tags:
-                        only: /^funmooc-.*/
-                name: lint-front-funmooc
-                requires:
-                    - build-front-production-funmooc
-                site: funmooc
-            - build-back:
-                filters:
-                    tags:
-                        only: /^funmooc-.*/
-                name: build-back-funmooc
-                site: funmooc
-            - lint-back:
-                filters:
-                    tags:
-                        only: /^funmooc-.*/
-                name: lint-back-funmooc
-                requires:
-                    - build-back-funmooc
-                site: funmooc
-            - test-back:
-                filters:
-                    tags:
-                        only: /^funmooc-.*/
-                name: test-back-funmooc
-                requires:
-                    - build-back-funmooc
-                site: funmooc
-            - hub:
-                filters:
-                    tags:
-                        only: /^funmooc-.*/
-                image_name: funmooc
-                name: hub-funmooc
-                requires:
-                    - lint-front-funmooc
-                    - lint-back-funmooc
-                site: funmooc
+                        only: /.*/
+                name: no-change-funmooc
     site-factory:
         jobs:
             - lint-git:
@@ -739,7 +684,7 @@ workflows:
                     tags:
                         only: /.*/
             - check-configuration:
-                ci_update_options: --ignore-changelog
+                ci_update_options: ""
                 filters:
                     branches:
                         ignore: main

--- a/sites/ademe/CHANGELOG.md
+++ b/sites/ademe/CHANGELOG.md
@@ -9,6 +9,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Migrate to new STORAGES settings
+
 ## [0.20.1] - 2024-04-18
 
 ### Fixed

--- a/sites/ademe/src/backend/ademe/settings.py
+++ b/sites/ademe/src/backend/ademe/settings.py
@@ -291,7 +291,14 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
     # For static files, we want to use a backend that includes a hash in
     # the filename, that is calculated from the file content, so that browsers always
     # get the updated version of each file.
-    STATICFILES_STORAGE = values.Value("base.storage.CDNManifestStaticFilesStorage")
+    STORAGES = {
+        "default": {
+            "BACKEND": "django.core.files.storage.FileSystemStorage",
+        },
+        "staticfiles": {
+            "BACKEND": "base.storage.CDNManifestStaticFilesStorage",
+        },
+    }
 
     AUTHENTICATION_BACKENDS = ("django.contrib.auth.backends.ModelBackend",)
 
@@ -1019,7 +1026,14 @@ class Development(Base):
 class Test(Base):
     """Test environment settings"""
 
-    STATICFILES_STORAGE = "django.contrib.staticfiles.storage.StaticFilesStorage"
+    STORAGES = {
+        "default": {
+            "BACKEND": "django.core.files.storage.FileSystemStorage",
+        },
+        "staticfiles": {
+            "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage",
+        },
+    }
 
 
 class ContinuousIntegration(Test):
@@ -1046,7 +1060,14 @@ class Production(Base):
     SECURE_CONTENT_TYPE_NOSNIFF = True
     SESSION_COOKIE_SECURE = True
 
-    DEFAULT_FILE_STORAGE = "base.storage.MediaStorage"
+    STORAGES = {
+        "default": {
+            "BACKEND": "base.storage.MediaStorage",
+        },
+        "staticfiles": {
+            "BACKEND": "base.storage.CDNManifestStaticFilesStorage",
+        },
+    }
     AWS_DEFAULT_ACL = None
     AWS_LOCATION = "media"
 

--- a/sites/ademe/src/backend/base/storage.py
+++ b/sites/ademe/src/backend/base/storage.py
@@ -8,7 +8,9 @@ from django.contrib.staticfiles.storage import ManifestStaticFilesStorage
 
 from storages.backends.s3boto3 import S3Boto3Storage
 
-STATIC_POSTPROCESS_IGNORE_REGEX = re.compile(r"^richie\/js\/[0-9]*\..*\.index\.js$")
+STATIC_POSTPROCESS_IGNORE_REGEX = re.compile(
+    r"^richie\/js\/build\/[0-9]*\..*\.index\.js(\.map)?$"
+)
 
 
 class CDNManifestStaticFilesStorage(ManifestStaticFilesStorage):

--- a/sites/demo/CHANGELOG.md
+++ b/sites/demo/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Migrate to new STORAGES settings
+
 ## [1.27.1] - 2023-08-30
 
 ### Fixed

--- a/sites/demo/src/backend/base/storage.py
+++ b/sites/demo/src/backend/base/storage.py
@@ -7,7 +7,9 @@ from django.contrib.staticfiles.storage import ManifestStaticFilesStorage
 
 from storages.backends.s3boto3 import S3Boto3Storage
 
-STATIC_POSTPROCESS_IGNORE_REGEX = re.compile(r"^richie\/js\/[0-9]*\..*\.index\.js$")
+STATIC_POSTPROCESS_IGNORE_REGEX = re.compile(
+    r"^richie\/js\/build\/[0-9]*\..*\.index\.js(\.map)?$"
+)
 
 
 class CDNManifestStaticFilesStorage(ManifestStaticFilesStorage):

--- a/sites/demo/src/backend/demo/settings.py
+++ b/sites/demo/src/backend/demo/settings.py
@@ -195,7 +195,14 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
     # For static files, we want to use a backend that includes a hash in
     # the filename, that is calculated from the file content, so that browsers always
     # get the updated version of each file.
-    STATICFILES_STORAGE = values.Value("base.storage.CDNManifestStaticFilesStorage")
+    STORAGES = {
+        "default": {
+            "BACKEND": "django.core.files.storage.FileSystemStorage",
+        },
+        "staticfiles": {
+            "BACKEND": "base.storage.CDNManifestStaticFilesStorage",
+        },
+    }
 
     AUTHENTICATION_BACKENDS = ("django.contrib.auth.backends.ModelBackend",)
 
@@ -309,18 +316,6 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
     USE_L10N = True
     USE_TZ = True
     LOCALE_PATHS = [os.path.join(BASE_DIR, "locale")]
-
-    # Mapping between edx and richie profile fields
-    EDX_USER_PROFILE_TO_DJANGO = {
-        "preferred_username": "username",
-        "email": "email",
-        "name": "full_name",
-        "given_name": "first_name",
-        "family_name": "last_name",
-        "locale": "language",
-        "user_id": "user_id",
-        "administrator": "is_staff",
-    }
 
     # Templates
     TEMPLATES = [
@@ -708,7 +703,14 @@ class Development(Base):
 class Test(Base):
     """Test environment settings"""
 
-    STATICFILES_STORAGE = "django.contrib.staticfiles.storage.StaticFilesStorage"
+    STORAGES = {
+        "default": {
+            "BACKEND": "django.core.files.storage.FileSystemStorage",
+        },
+        "staticfiles": {
+            "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage",
+        },
+    }
 
 
 class ContinuousIntegration(Test):
@@ -734,8 +736,6 @@ class Production(Base):
     SECURE_BROWSER_XSS_FILTER = True
     SECURE_CONTENT_TYPE_NOSNIFF = True
     SESSION_COOKIE_SECURE = True
-
-    DEFAULT_FILE_STORAGE = "base.storage.MediaStorage"
     AWS_DEFAULT_ACL = None
     AWS_LOCATION = "media"
 
@@ -750,6 +750,15 @@ class Production(Base):
     AWS_S3_REGION_NAME = values.Value("eu-west-1")
 
     AWS_MEDIA_BUCKET_NAME = values.Value("production-richie-media")
+
+    STORAGES = {
+        "default": {
+            "BACKEND": "base.storage.MediaStorage",
+        },
+        "staticfiles": {
+            "BACKEND": "base.storage.CDNManifestStaticFilesStorage",
+        },
+    }
 
     # CDN domain for static/media urls. It is passed to the frontend to load built chunks
     CDN_DOMAIN = values.Value()

--- a/sites/funcampus/CHANGELOG.md
+++ b/sites/funcampus/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Migrate to new STORAGES settings
+
 ## [1.26.0] - 2023-10-31
 
 ### Changed

--- a/sites/funcampus/src/backend/base/storage.py
+++ b/sites/funcampus/src/backend/base/storage.py
@@ -7,7 +7,9 @@ from django.contrib.staticfiles.storage import ManifestStaticFilesStorage
 
 from storages.backends.s3boto3 import S3Boto3Storage
 
-STATIC_POSTPROCESS_IGNORE_REGEX = re.compile(r"^richie\/js\/[0-9]*\..*\.index\.js$")
+STATIC_POSTPROCESS_IGNORE_REGEX = re.compile(
+    r"^richie\/js\/build\/[0-9]*\..*\.index\.js(\.map)?$"
+)
 
 
 class CDNManifestStaticFilesStorage(ManifestStaticFilesStorage):

--- a/sites/funcampus/src/backend/funcampus/settings.py
+++ b/sites/funcampus/src/backend/funcampus/settings.py
@@ -195,7 +195,14 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
     # For static files, we want to use a backend that includes a hash in
     # the filename, that is calculated from the file content, so that browsers always
     # get the updated version of each file.
-    STATICFILES_STORAGE = values.Value("base.storage.CDNManifestStaticFilesStorage")
+    STORAGES = {
+        "default": {
+            "BACKEND": "django.core.files.storage.FileSystemStorage",
+        },
+        "staticfiles": {
+            "BACKEND": "base.storage.CDNManifestStaticFilesStorage",
+        },
+    }
 
     # Login/registration related settings
     LOGIN_REDIRECT_URL = "/"
@@ -877,7 +884,14 @@ class Development(Base):
 class Test(Base):
     """Test environment settings"""
 
-    STATICFILES_STORAGE = "django.contrib.staticfiles.storage.StaticFilesStorage"
+    STORAGES = {
+        "default": {
+            "BACKEND": "django.core.files.storage.FileSystemStorage",
+        },
+        "staticfiles": {
+            "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage",
+        },
+    }
 
 
 class ContinuousIntegration(Test):
@@ -904,7 +918,14 @@ class Production(Base):
     SECURE_CONTENT_TYPE_NOSNIFF = True
     SESSION_COOKIE_SECURE = True
 
-    DEFAULT_FILE_STORAGE = "base.storage.MediaStorage"
+    STORAGES = {
+        "default": {
+            "BACKEND": "base.storage.MediaStorage",
+        },
+        "staticfiles": {
+            "BACKEND": "base.storage.CDNManifestStaticFilesStorage",
+        },
+    }
     AWS_DEFAULT_ACL = None
     AWS_LOCATION = "media"
 

--- a/sites/funcorporate/CHANGELOG.md
+++ b/sites/funcorporate/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Migrate to new STORAGES settings
+
 ## [1.26.1] - 2023-11-02
 
 ### Fixed

--- a/sites/funcorporate/src/backend/base/storage.py
+++ b/sites/funcorporate/src/backend/base/storage.py
@@ -7,7 +7,9 @@ from django.contrib.staticfiles.storage import ManifestStaticFilesStorage
 
 from storages.backends.s3boto3 import S3Boto3Storage
 
-STATIC_POSTPROCESS_IGNORE_REGEX = re.compile(r"^richie\/js\/[0-9]*\..*\.index\.js$")
+STATIC_POSTPROCESS_IGNORE_REGEX = re.compile(
+    r"^richie\/js\/build\/[0-9]*\..*\.index\.js(\.map)?$"
+)
 
 
 class CDNManifestStaticFilesStorage(ManifestStaticFilesStorage):

--- a/sites/funcorporate/src/backend/funcorporate/settings.py
+++ b/sites/funcorporate/src/backend/funcorporate/settings.py
@@ -191,7 +191,14 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
     # For static files, we want to use a backend that includes a hash in
     # the filename, that is calculated from the file content, so that browsers always
     # get the updated version of each file.
-    STATICFILES_STORAGE = values.Value("base.storage.CDNManifestStaticFilesStorage")
+    STORAGES = {
+        "default": {
+            "BACKEND": "django.core.files.storage.FileSystemStorage",
+        },
+        "staticfiles": {
+            "BACKEND": "base.storage.CDNManifestStaticFilesStorage",
+        },
+    }
 
     # Login/registration related settings
     LOGIN_REDIRECT_URL = "/"
@@ -826,7 +833,14 @@ class Development(Base):
 class Test(Base):
     """Test environment settings"""
 
-    STATICFILES_STORAGE = "django.contrib.staticfiles.storage.StaticFilesStorage"
+    STORAGES = {
+        "default": {
+            "BACKEND": "django.core.files.storage.FileSystemStorage",
+        },
+        "staticfiles": {
+            "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage",
+        },
+    }
 
 
 class ContinuousIntegration(Test):
@@ -853,7 +867,14 @@ class Production(Base):
     SECURE_CONTENT_TYPE_NOSNIFF = True
     SESSION_COOKIE_SECURE = True
 
-    DEFAULT_FILE_STORAGE = "base.storage.MediaStorage"
+    STORAGES = {
+        "default": {
+            "BACKEND": "base.storage.MediaStorage",
+        },
+        "staticfiles": {
+            "BACKEND": "base.storage.CDNManifestStaticFilesStorage",
+        },
+    }
     AWS_DEFAULT_ACL = None
     AWS_LOCATION = "media"
 


### PR DESCRIPTION
Except for FUN Mooc which is already migrated, all other sites settings must be updated to use the new django STORAGES settings added in Django 4.2 as without this migration, we are not able anymore to build a docker image.