### PR TITLE
⬆️(ademe) upgrade python dependencies

### DIFF
--- a/sites/ademe/CHANGELOG.md
+++ b/sites/ademe/CHANGELOG.md
@@ -12,6 +12,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - Upgrade to richie 2.28.1
+- Migrate to Sentry SDK 2.0
 - Migrate to new STORAGES settings
 
 ## [0.20.1] - 2024-04-18

--- a/sites/ademe/requirements/base.txt
+++ b/sites/ademe/requirements/base.txt
@@ -1,13 +1,10 @@
-boto3==1.28.9
-django-check-seo==0.6.4
-# Remove django-cms dep when upgrading to richie 2.25.0
-django-cms>=3.11.0,<4.0.0
-django-configurations==2.4.1
-django-storages==1.13.2
-dockerflow==2022.8.0
-factory-boy==3.2.1
+boto3==1.34.109
+django-check-seo==1.0.1
+django-configurations==2.5.1
+django-storages==1.14.3
+dockerflow==2024.4.2
+factory-boy==3.3.0
 gunicorn==22.0.0
-psycopg2-binary==2.9.6
+psycopg2-binary==2.9.9
 richie==2.28.1
-unidecode==1.3.6 # required by django-check-seo
-sentry-sdk==1.28.1
+sentry-sdk==2.2.1

--- a/sites/ademe/src/backend/ademe/settings.py
+++ b/sites/ademe/src/backend/ademe/settings.py
@@ -964,8 +964,7 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
                 release=get_release(),
                 integrations=[DjangoIntegration()],
             )
-            with sentry_sdk.configure_scope() as scope:
-                scope.set_extra("application", "backend")
+            sentry_sdk.set_tag("application", "backend")
 
         # If a Joanie Backend has been configured, we add it into LMS_BACKENDS dict
         if cls.JOANIE_BACKEND.get("BASE_URL") is not None:


### PR DESCRIPTION
Ademe python dependencies were too old, we upgrade them to match version used on
 FUN Mooc. This include a migration to Sentry SDK 2.0