### PR TITLE
🐛(canary) collector step must be made with the richie next version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -398,11 +398,66 @@ version: 2.1
 workflows:
     ademe:
         jobs:
-            - no-change:
+            - check-changelog:
+                filters:
+                    branches:
+                        ignore: /.*/
+                name: check-changelog-ademe
+                site: ademe
+            - lint-changelog:
+                filters:
+                    branches:
+                        ignore: main
+                    tags:
+                        only: /^ademe-.*/
+                name: lint-changelog--ademe
+                site: ademe
+            - build-front-production:
                 filters:
                     tags:
-                        only: /.*/
-                name: no-change-ademe
+                        only: /^ademe-.*/
+                name: build-front-production-ademe
+                site: ademe
+            - lint-front:
+                filters:
+                    tags:
+                        only: /^ademe-.*/
+                name: lint-front-ademe
+                requires:
+                    - build-front-production-ademe
+                site: ademe
+            - build-back:
+                filters:
+                    tags:
+                        only: /^ademe-.*/
+                name: build-back-ademe
+                site: ademe
+            - lint-back:
+                filters:
+                    tags:
+                        only: /^ademe-.*/
+                name: lint-back-ademe
+                requires:
+                    - build-back-ademe
+                site: ademe
+            - test-back:
+                filters:
+                    tags:
+                        only: /^ademe-.*/
+                name: test-back-ademe
+                requires:
+                    - build-back-ademe
+                site: ademe
+            - hub:
+                filters:
+                    tags:
+                        only: /^ademe-.*/
+                image_name: ademe
+                name: hub-ademe
+                requires:
+                    - lint-front-ademe
+                    - lint-back-ademe
+                site: ademe
     canary:
         jobs:
             - hub-canary:
@@ -431,31 +486,196 @@ workflows:
                 - << pipeline.schedule.name >>
     demo:
         jobs:
-            - no-change:
+            - check-changelog:
+                filters:
+                    branches:
+                        ignore: /.*/
+                name: check-changelog-demo
+                site: demo
+            - lint-changelog:
+                filters:
+                    branches:
+                        ignore: main
+                    tags:
+                        only: /^demo-.*/
+                name: lint-changelog--demo
+                site: demo
+            - build-front-production:
                 filters:
                     tags:
-                        only: /.*/
-                name: no-change-demo
+                        only: /^demo-.*/
+                name: build-front-production-demo
+                site: demo
+            - lint-front:
+                filters:
+                    tags:
+                        only: /^demo-.*/
+                name: lint-front-demo
+                requires:
+                    - build-front-production-demo
+                site: demo
+            - build-back:
+                filters:
+                    tags:
+                        only: /^demo-.*/
+                name: build-back-demo
+                site: demo
+            - lint-back:
+                filters:
+                    tags:
+                        only: /^demo-.*/
+                name: lint-back-demo
+                requires:
+                    - build-back-demo
+                site: demo
+            - test-back:
+                filters:
+                    tags:
+                        only: /^demo-.*/
+                name: test-back-demo
+                requires:
+                    - build-back-demo
+                site: demo
+            - hub:
+                filters:
+                    tags:
+                        only: /^demo-.*/
+                image_name: richie-demo
+                name: hub-demo
+                requires:
+                    - lint-front-demo
+                    - lint-back-demo
+                site: demo
     funcampus:
         jobs:
-            - no-change:
+            - check-changelog:
+                filters:
+                    branches:
+                        ignore: /.*/
+                name: check-changelog-funcampus
+                site: funcampus
+            - lint-changelog:
+                filters:
+                    branches:
+                        ignore: main
+                    tags:
+                        only: /^funcampus-.*/
+                name: lint-changelog--funcampus
+                site: funcampus
+            - build-front-production:
                 filters:
                     tags:
-                        only: /.*/
-                name: no-change-funcampus
+                        only: /^funcampus-.*/
+                name: build-front-production-funcampus
+                site: funcampus
+            - lint-front:
+                filters:
+                    tags:
+                        only: /^funcampus-.*/
+                name: lint-front-funcampus
+                requires:
+                    - build-front-production-funcampus
+                site: funcampus
+            - build-back:
+                filters:
+                    tags:
+                        only: /^funcampus-.*/
+                name: build-back-funcampus
+                site: funcampus
+            - lint-back:
+                filters:
+                    tags:
+                        only: /^funcampus-.*/
+                name: lint-back-funcampus
+                requires:
+                    - build-back-funcampus
+                site: funcampus
+            - test-back:
+                filters:
+                    tags:
+                        only: /^funcampus-.*/
+                name: test-back-funcampus
+                requires:
+                    - build-back-funcampus
+                site: funcampus
+            - hub:
+                filters:
+                    tags:
+                        only: /^funcampus-.*/
+                image_name: funcampus
+                name: hub-funcampus
+                requires:
+                    - lint-front-funcampus
+                    - lint-back-funcampus
+                site: funcampus
     funcorporate:
         jobs:
-            - no-change:
+            - check-changelog:
+                filters:
+                    branches:
+                        ignore: /.*/
+                name: check-changelog-funcorporate
+                site: funcorporate
+            - lint-changelog:
+                filters:
+                    branches:
+                        ignore: main
+                    tags:
+                        only: /^funcorporate-.*/
+                name: lint-changelog--funcorporate
+                site: funcorporate
+            - build-front-production:
                 filters:
                     tags:
-                        only: /.*/
-                name: no-change-funcorporate
+                        only: /^funcorporate-.*/
+                name: build-front-production-funcorporate
+                site: funcorporate
+            - lint-front:
+                filters:
+                    tags:
+                        only: /^funcorporate-.*/
+                name: lint-front-funcorporate
+                requires:
+                    - build-front-production-funcorporate
+                site: funcorporate
+            - build-back:
+                filters:
+                    tags:
+                        only: /^funcorporate-.*/
+                name: build-back-funcorporate
+                site: funcorporate
+            - lint-back:
+                filters:
+                    tags:
+                        only: /^funcorporate-.*/
+                name: lint-back-funcorporate
+                requires:
+                    - build-back-funcorporate
+                site: funcorporate
+            - test-back:
+                filters:
+                    tags:
+                        only: /^funcorporate-.*/
+                name: test-back-funcorporate
+                requires:
+                    - build-back-funcorporate
+                site: funcorporate
+            - hub:
+                filters:
+                    tags:
+                        only: /^funcorporate-.*/
+                image_name: funcorporate
+                name: hub-funcorporate
+                requires:
+                    - lint-front-funcorporate
+                    - lint-back-funcorporate
+                site: funcorporate
     funmooc:
         jobs:
             - check-changelog:
                 filters:
                     branches:
-                        ignore: main
+                        ignore: /.*/
                 name: check-changelog-funmooc
                 site: funmooc
             - lint-changelog:
@@ -519,7 +739,7 @@ workflows:
                     tags:
                         only: /.*/
             - check-configuration:
-                ci_update_options: ""
+                ci_update_options: --ignore-changelog
                 filters:
                     branches:
                         ignore: main

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,11 +50,11 @@ services:
   app-canary:
     build:
       context: .
-      target: canary
+      target: production
       args:
         DOCKER_USER: ${DOCKER_USER:-1000}
         SITE: ${RICHIE_SITE:-funmooc}
-        BUILD_NEXT_FRONT: 1
+        BUILD_NEXT_VERSION: 1
     image: "${RICHIE_SITE:-funmooc}:canary"
     environment:
       - DB_NAME=richie_${RICHIE_SITE:-funmooc}
@@ -127,7 +127,7 @@ services:
         NGINX_IMAGE_NAME: ${NGINX_IMAGE_NAME:-fundocker/openshift-nginx}
         NGINX_IMAGE_TAG: ${NGINX_IMAGE_TAG:-1.13}
         SITE: ${RICHIE_SITE:-funmooc}
-        BUILD_NEXT_FRONT: 1
+        BUILD_NEXT_VERSION: 1
     image: "${RICHIE_SITE:-funmooc}-nginx:canary"
     ports:
       - "8082:8081"


### PR DESCRIPTION
The collector step in the Dockerfile is made using the richie version set in the backend requirements. If new statics are added in the next tag then they will not be present. To fix that, the uninstallation of richie and the installtion of the next version is made in the core stage. Doing that, the canary stage is not needed anymore and the argument BUILD_NEXT_FRONT is rename in BUILD_NEXT_VERSION to be more accurate.