### PR TITLE
✨(funmooc) add middleware to clean query strings

### DIFF
--- a/sites/funmooc/CHANGELOG.md
+++ b/sites/funmooc/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Add a middleware in charge of detecting malformed query strings
+
 ## [1.39.0] - 2024-12-02
 
 ### Changed

--- a/sites/funmooc/src/backend/base/middleware.py
+++ b/sites/funmooc/src/backend/base/middleware.py
@@ -1,0 +1,25 @@
+"""Middleware for the FUN Mooc base app."""
+
+from urllib.parse import unquote, urlparse
+
+from django.core.exceptions import BadRequest
+from django.utils.deprecation import MiddlewareMixin
+
+
+class MalformedQueryStringMiddleware(MiddlewareMixin):
+    """
+    A middleware to detect malformed query string from the request. It detects malformed
+    query string then raise a BadRequest exception if one is found.
+    """
+
+    def process_request(self, request):
+        """
+        Catch the path of the request and raise a BadRequest exception if
+        the query string is malformed (contains several ?).
+        Api endpoints and non GET requests are ignored.
+        """
+        parsed_url = urlparse(request.get_full_path())
+
+        if request.method == "GET" and not parsed_url.path.startswith("/api/v"):
+            if unquote(parsed_url.query).find("?") != -1:
+                raise BadRequest("URL query string is malformed.")

--- a/sites/funmooc/src/backend/base/tests/test_middleware.py
+++ b/sites/funmooc/src/backend/base/tests/test_middleware.py
@@ -1,0 +1,52 @@
+"""Test suite for the base app middlewares."""
+
+from django.core.exceptions import BadRequest
+from django.http import HttpRequest
+from django.test import TestCase
+
+from base.middleware import MalformedQueryStringMiddleware
+
+
+class TestMalformedQueryStringMiddleware(TestCase):
+    """Test case for the MalformedQueryStringMiddleware."""
+
+    def test_malformed_query_string_middleware_self(self):
+        """
+        If a query string is malformed, a bad request should be returned.
+        """
+        request = HttpRequest()
+        request.method = "GET"
+        request.META["QUERY_STRING"] = "foo=bar?bar=foo"
+        request.path = "/"
+
+        with self.assertRaises(BadRequest):
+            MalformedQueryStringMiddleware(request).process_request(request)
+
+        # Encoded chars should be decoded
+        request.META["QUERY_STRING"] = "foo=bar%3Fbar=foo"
+
+        with self.assertRaises(BadRequest):
+            MalformedQueryStringMiddleware(request).process_request(request)
+
+    def test_malformed_query_string_middleware_ignore_api_endpoint(self):
+        """
+        If the request path is an api endpoint, the middleware should ignore it.
+        """
+        request = HttpRequest()
+        request.method = "GET"
+        request.META["QUERY_STRING"] = "q=Hello?"
+        request.path = "/api/v1.0/search/"
+
+        MalformedQueryStringMiddleware(request).process_request(request)
+
+    def test_malformed_query_string_middleware_ignore_non_get_request(self):
+        """
+        If the request method is something else than GET,
+        the middleware should ignore it.
+        """
+        request = HttpRequest()
+        request.method = "POST"
+        request.META["QUERY_STRING"] = "q=Hello?"
+        request.path = "/api/v1.0/search/"
+
+        MalformedQueryStringMiddleware(request).process_request(request)

--- a/sites/funmooc/src/backend/base/tests/test_template.py
+++ b/sites/funmooc/src/backend/base/tests/test_template.py
@@ -55,7 +55,7 @@ class TemplateProfessionalTrainingDetailTestCase(TestCase):
 
         # The template should extend the `courses/cms/course_detail.html` template
         with self.assertTemplateUsed("courses/cms/course_detail.html"):
-            response = self.client.get(url)
+            response = self.client.get(url, follow=True)
 
         self.assertEqual(response.status_code, 200)
         html = lxml.html.fromstring(str(response.content.decode("utf-8")))

--- a/sites/funmooc/src/backend/funmooc/settings.py
+++ b/sites/funmooc/src/backend/funmooc/settings.py
@@ -415,6 +415,7 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
     )
 
     MIDDLEWARE = (
+        "base.middleware.MalformedQueryStringMiddleware",
         "richie.apps.core.cache.LimitBrowserCacheTTLHeaders",
         "cms.middleware.utils.ApphookReloadMiddleware",
         "django.middleware.security.SecurityMiddleware",


### PR DESCRIPTION
Some bots are spamming fun mooc by producing urls with malformed query strings. In order to prevent this spam, we implement a middleware in charge of cleaning query strings then redirect to a clean url if needed.