### PR TITLE
Fix/ignore admin endpoints from malformed query string middleware

### DIFF
--- a/sites/funmooc/CHANGELOG.md
+++ b/sites/funmooc/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.40.1] - 2025-01-27
+
 ### Fixed
 
 - Ignore admin endpoints in the middleware that detects malformed query strings
@@ -775,7 +777,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Static and media files are stored in AWS S3 buckets and distributed _via_
   Amazon CloudFront
 
-[unreleased]: https://github.com/openfun/fun-richie-site-factory/compare/funmooc-1.40.0...HEAD
+[unreleased]: https://github.com/openfun/fun-richie-site-factory/compare/funmooc-1.40.1...HEAD
+[1.40.1]: https://github.com/openfun/fun-richie-site-factory/compare/funmooc-1.40.0...funmooc-1.40.1
 [1.40.0]: https://github.com/openfun/fun-richie-site-factory/compare/funmooc-1.39.0...funmooc-1.40.0
 [1.39.0]: https://github.com/openfun/fun-richie-site-factory/compare/funmooc-1.38.0...funmooc-1.39.0
 [1.38.0]: https://github.com/openfun/fun-richie-site-factory/compare/funmooc-1.37.0...funmooc-1.38.0

--- a/sites/funmooc/CHANGELOG.md
+++ b/sites/funmooc/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Ignore admin endpoints in the middleware that detects malformed query strings
+
 ## [1.40.0] - 2025-01-23
 
 ### Added

--- a/sites/funmooc/src/backend/base/tests/test_middleware.py
+++ b/sites/funmooc/src/backend/base/tests/test_middleware.py
@@ -1,6 +1,5 @@
 """Test suite for the base app middlewares."""
 
-from django.core.exceptions import BadRequest
 from django.http import HttpRequest
 from django.test import TestCase
 
@@ -19,14 +18,16 @@ class TestMalformedQueryStringMiddleware(TestCase):
         request.META["QUERY_STRING"] = "foo=bar?bar=foo"
         request.path = "/"
 
-        with self.assertRaises(BadRequest):
-            MalformedQueryStringMiddleware(request).process_request(request)
+        response = MalformedQueryStringMiddleware(request).process_request(request)
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.content, b"URL query string is malformed.")
 
         # Encoded chars should be decoded
         request.META["QUERY_STRING"] = "foo=bar%3Fbar=foo"
 
-        with self.assertRaises(BadRequest):
-            MalformedQueryStringMiddleware(request).process_request(request)
+        response = MalformedQueryStringMiddleware(request).process_request(request)
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.content, b"URL query string is malformed.")
 
     def test_malformed_query_string_middleware_ignore_api_endpoint(self):
         """
@@ -37,7 +38,20 @@ class TestMalformedQueryStringMiddleware(TestCase):
         request.META["QUERY_STRING"] = "q=Hello?"
         request.path = "/api/v1.0/search/"
 
-        MalformedQueryStringMiddleware(request).process_request(request)
+        response = MalformedQueryStringMiddleware(request).process_request(request)
+        self.assertIsNone(response)
+
+    def test_malformed_query_string_middleware_ignore_admin_endpoint(self):
+        """
+        If the request path is an admin endpoint, the middleware should ignore it.
+        """
+        request = HttpRequest()
+        request.method = "GET"
+        request.META["QUERY_STRING"] = "?placeholder_id=1&cms_path=/en/news/test/?edit"
+        request.path = "/en/admin/cms/page/add-plugin/"
+
+        response = MalformedQueryStringMiddleware(request).process_request(request)
+        self.assertIsNone(response)
 
     def test_malformed_query_string_middleware_ignore_non_get_request(self):
         """
@@ -49,4 +63,5 @@ class TestMalformedQueryStringMiddleware(TestCase):
         request.META["QUERY_STRING"] = "q=Hello?"
         request.path = "/api/v1.0/search/"
 
-        MalformedQueryStringMiddleware(request).process_request(request)
+        response = MalformedQueryStringMiddleware(request).process_request(request)
+        self.assertIsNone(response)

--- a/sites/funmooc/src/backend/funmooc/__init__.py
+++ b/sites/funmooc/src/backend/funmooc/__init__.py
@@ -1,3 +1,3 @@
 """funmooc application"""
 
-__version__ = "1.40.0"
+__version__ = "1.40.1"

--- a/sites/funmooc/src/frontend/package.json
+++ b/sites/funmooc/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "funmooc",
-  "version": "1.40.0",
+  "version": "1.40.1",
   "description": "Richie-powered CMS for fun-mooc.fr",
   "scripts": {
     "build-sass": "sass scss/_main.scss ../backend/base/static/richie/css/main.css --load-path=node_modules",


### PR DESCRIPTION
With the new MalformedQueryStringMiddleware, currently admin endpoints
are checked and it prevents editor to add plugin on a page... so we have
 to exclude those paths to the check. Furthermore, instead of raising a
 BadRequest exception we now return a HttpBadRequestResponse. In this
 way, the request workflow is stopped here and a 400 is returned to the
 client instead of a 500.

Then release funmooc-1.40.1