### PR TITLE
⬆️(all) upgrade to django-cms 3.11.9

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -398,11 +398,66 @@ version: 2.1
 workflows:
     ademe:
         jobs:
-            - no-change:
+            - check-changelog:
+                filters:
+                    branches:
+                        ignore: /.*/
+                name: check-changelog-ademe
+                site: ademe
+            - lint-changelog:
+                filters:
+                    branches:
+                        ignore: main
+                    tags:
+                        only: /^ademe-.*/
+                name: lint-changelog--ademe
+                site: ademe
+            - build-front-production:
                 filters:
                     tags:
-                        only: /.*/
-                name: no-change-ademe
+                        only: /^ademe-.*/
+                name: build-front-production-ademe
+                site: ademe
+            - lint-front:
+                filters:
+                    tags:
+                        only: /^ademe-.*/
+                name: lint-front-ademe
+                requires:
+                    - build-front-production-ademe
+                site: ademe
+            - build-back:
+                filters:
+                    tags:
+                        only: /^ademe-.*/
+                name: build-back-ademe
+                site: ademe
+            - lint-back:
+                filters:
+                    tags:
+                        only: /^ademe-.*/
+                name: lint-back-ademe
+                requires:
+                    - build-back-ademe
+                site: ademe
+            - test-back:
+                filters:
+                    tags:
+                        only: /^ademe-.*/
+                name: test-back-ademe
+                requires:
+                    - build-back-ademe
+                site: ademe
+            - hub:
+                filters:
+                    tags:
+                        only: /^ademe-.*/
+                image_name: ademe
+                name: hub-ademe
+                requires:
+                    - lint-front-ademe
+                    - lint-back-ademe
+                site: ademe
     canary:
         jobs:
             - hub-canary:
@@ -431,31 +486,196 @@ workflows:
                 - << pipeline.schedule.name >>
     demo:
         jobs:
-            - no-change:
+            - check-changelog:
+                filters:
+                    branches:
+                        ignore: /.*/
+                name: check-changelog-demo
+                site: demo
+            - lint-changelog:
+                filters:
+                    branches:
+                        ignore: main
+                    tags:
+                        only: /^demo-.*/
+                name: lint-changelog--demo
+                site: demo
+            - build-front-production:
                 filters:
                     tags:
-                        only: /.*/
-                name: no-change-demo
+                        only: /^demo-.*/
+                name: build-front-production-demo
+                site: demo
+            - lint-front:
+                filters:
+                    tags:
+                        only: /^demo-.*/
+                name: lint-front-demo
+                requires:
+                    - build-front-production-demo
+                site: demo
+            - build-back:
+                filters:
+                    tags:
+                        only: /^demo-.*/
+                name: build-back-demo
+                site: demo
+            - lint-back:
+                filters:
+                    tags:
+                        only: /^demo-.*/
+                name: lint-back-demo
+                requires:
+                    - build-back-demo
+                site: demo
+            - test-back:
+                filters:
+                    tags:
+                        only: /^demo-.*/
+                name: test-back-demo
+                requires:
+                    - build-back-demo
+                site: demo
+            - hub:
+                filters:
+                    tags:
+                        only: /^demo-.*/
+                image_name: richie-demo
+                name: hub-demo
+                requires:
+                    - lint-front-demo
+                    - lint-back-demo
+                site: demo
     funcampus:
         jobs:
-            - no-change:
+            - check-changelog:
+                filters:
+                    branches:
+                        ignore: /.*/
+                name: check-changelog-funcampus
+                site: funcampus
+            - lint-changelog:
+                filters:
+                    branches:
+                        ignore: main
+                    tags:
+                        only: /^funcampus-.*/
+                name: lint-changelog--funcampus
+                site: funcampus
+            - build-front-production:
                 filters:
                     tags:
-                        only: /.*/
-                name: no-change-funcampus
+                        only: /^funcampus-.*/
+                name: build-front-production-funcampus
+                site: funcampus
+            - lint-front:
+                filters:
+                    tags:
+                        only: /^funcampus-.*/
+                name: lint-front-funcampus
+                requires:
+                    - build-front-production-funcampus
+                site: funcampus
+            - build-back:
+                filters:
+                    tags:
+                        only: /^funcampus-.*/
+                name: build-back-funcampus
+                site: funcampus
+            - lint-back:
+                filters:
+                    tags:
+                        only: /^funcampus-.*/
+                name: lint-back-funcampus
+                requires:
+                    - build-back-funcampus
+                site: funcampus
+            - test-back:
+                filters:
+                    tags:
+                        only: /^funcampus-.*/
+                name: test-back-funcampus
+                requires:
+                    - build-back-funcampus
+                site: funcampus
+            - hub:
+                filters:
+                    tags:
+                        only: /^funcampus-.*/
+                image_name: funcampus
+                name: hub-funcampus
+                requires:
+                    - lint-front-funcampus
+                    - lint-back-funcampus
+                site: funcampus
     funcorporate:
         jobs:
-            - no-change:
+            - check-changelog:
+                filters:
+                    branches:
+                        ignore: /.*/
+                name: check-changelog-funcorporate
+                site: funcorporate
+            - lint-changelog:
+                filters:
+                    branches:
+                        ignore: main
+                    tags:
+                        only: /^funcorporate-.*/
+                name: lint-changelog--funcorporate
+                site: funcorporate
+            - build-front-production:
                 filters:
                     tags:
-                        only: /.*/
-                name: no-change-funcorporate
+                        only: /^funcorporate-.*/
+                name: build-front-production-funcorporate
+                site: funcorporate
+            - lint-front:
+                filters:
+                    tags:
+                        only: /^funcorporate-.*/
+                name: lint-front-funcorporate
+                requires:
+                    - build-front-production-funcorporate
+                site: funcorporate
+            - build-back:
+                filters:
+                    tags:
+                        only: /^funcorporate-.*/
+                name: build-back-funcorporate
+                site: funcorporate
+            - lint-back:
+                filters:
+                    tags:
+                        only: /^funcorporate-.*/
+                name: lint-back-funcorporate
+                requires:
+                    - build-back-funcorporate
+                site: funcorporate
+            - test-back:
+                filters:
+                    tags:
+                        only: /^funcorporate-.*/
+                name: test-back-funcorporate
+                requires:
+                    - build-back-funcorporate
+                site: funcorporate
+            - hub:
+                filters:
+                    tags:
+                        only: /^funcorporate-.*/
+                image_name: funcorporate
+                name: hub-funcorporate
+                requires:
+                    - lint-front-funcorporate
+                    - lint-back-funcorporate
+                site: funcorporate
     funmooc:
         jobs:
             - check-changelog:
                 filters:
                     branches:
-                        ignore: main
+                        ignore: /.*/
                 name: check-changelog-funmooc
                 site: funmooc
             - lint-changelog:
@@ -519,7 +739,7 @@ workflows:
                     tags:
                         only: /.*/
             - check-configuration:
-                ci_update_options: ""
+                ci_update_options: --ignore-changelog
                 filters:
                     branches:
                         ignore: main

--- a/sites/ademe/requirements/base.txt
+++ b/sites/ademe/requirements/base.txt
@@ -1,7 +1,7 @@
 boto3==1.34.109
 django-check-seo==1.0.1
 # Our django-cms fork which includes drillable search feature
-git+https://github.com/openfun/django-cms@fun-3.11.6#egg=django-cms
+git+https://github.com/openfun/django-cms@fun-3.11.9#egg=django-cms
 django-configurations==2.5.1
 django-storages==1.14.3
 dockerflow==2024.4.2

--- a/sites/demo/requirements/base.txt
+++ b/sites/demo/requirements/base.txt
@@ -1,7 +1,7 @@
 boto3==1.28.9
 django-check-seo==0.6.4
 # Our django-cms fork which includes drillable search feature
-git+https://github.com/openfun/django-cms@fun-3.11.6#egg=django-cms
+git+https://github.com/openfun/django-cms@fun-3.11.9#egg=django-cms
 django-configurations==2.4.1
 django-storages==1.13.2
 dockerflow==2022.8.0

--- a/sites/funcampus/requirements/base.txt
+++ b/sites/funcampus/requirements/base.txt
@@ -1,7 +1,7 @@
 boto3==1.28.9
 django-check-seo==0.6.4
 # Our django-cms fork which includes drillable search feature
-git+https://github.com/openfun/django-cms@fun-3.11.6#egg=django-cms
+git+https://github.com/openfun/django-cms@fun-3.11.9#egg=django-cms
 django-configurations==2.4.1
 django-storages==1.13.2
 dockerflow==2022.8.0

--- a/sites/funcorporate/requirements/base.txt
+++ b/sites/funcorporate/requirements/base.txt
@@ -1,7 +1,7 @@
 boto3==1.28.9
 django-check-seo==0.6.4
 # Our django-cms fork which includes drillable search feature
-git+https://github.com/openfun/django-cms@fun-3.11.6#egg=django-cms
+git+https://github.com/openfun/django-cms@fun-3.11.9#egg=django-cms
 django-configurations==2.4.1
 django-storages==1.13.2
 dockerflow==2022.8.0

--- a/sites/funmooc/requirements/base.txt
+++ b/sites/funmooc/requirements/base.txt
@@ -1,7 +1,7 @@
 boto3==1.34.109
 django-check-seo==1.0.1
 # Our django-cms fork which includes drillable search feature
-git+https://github.com/openfun/django-cms@fun-3.11.6#egg=django-cms
+git+https://github.com/openfun/django-cms@fun-3.11.9#egg=django-cms
 django-configurations==2.5.1
 django-storages==1.14.3
 dockerflow==2024.4.2


### PR DESCRIPTION
We recently upgrade our fork of django cms to the
latest 3.x version. So now we use this version in our factory.

https://github.com/openfun/django-cms/releases/tag/fun-3.11.9