### PR TITLE
✨(funcampus) add middleware to detect malformed query strings

### DIFF
--- a/sites/funcampus/CHANGELOG.md
+++ b/sites/funcampus/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Add a middleware in charge of detecting malformed query strings
+
 ### Changed
 
 - Upgrade richie to 3.0.0

--- a/sites/funcampus/src/backend/base/middleware.py
+++ b/sites/funcampus/src/backend/base/middleware.py
@@ -1,0 +1,37 @@
+"""Middleware for the FUN Campus base app."""
+
+import re
+from urllib.parse import unquote, urlparse
+
+from django.http import HttpResponseBadRequest
+from django.utils.deprecation import MiddlewareMixin
+
+
+class MalformedQueryStringMiddleware(MiddlewareMixin):
+    """
+    A middleware to detect malformed query string from the request. It detects malformed
+    query string then raise a BadRequest exception if one is found.
+    """
+
+    EXCLUDED_PATH_REGEX = (
+        r"(^/api/v)"  # Exclude API endpoints
+        r"|"
+        r"(^/[a-z-]+/admin/)"  # Exclude admin paths
+    )
+
+    def process_request(self, request):
+        """
+        Catch the path of the request and raise a BadRequest exception if
+        the query string is malformed (contains several ?).
+        Api endpoints and non GET requests are ignored.
+        """
+        parsed_url = urlparse(request.get_full_path())
+
+        if (
+            request.method == "GET"
+            and re.search(self.EXCLUDED_PATH_REGEX, parsed_url.path) is None
+        ):
+            if unquote(parsed_url.query).find("?") != -1:
+                return HttpResponseBadRequest("URL query string is malformed.")
+
+        return None

--- a/sites/funcampus/src/backend/base/tests/test_middleware.py
+++ b/sites/funcampus/src/backend/base/tests/test_middleware.py
@@ -1,0 +1,67 @@
+"""Test suite for the base app middlewares."""
+
+from django.http import HttpRequest
+from django.test import TestCase
+
+from base.middleware import MalformedQueryStringMiddleware
+
+
+class TestMalformedQueryStringMiddleware(TestCase):
+    """Test case for the MalformedQueryStringMiddleware."""
+
+    def test_malformed_query_string_middleware_self(self):
+        """
+        If a query string is malformed, a bad request should be returned.
+        """
+        request = HttpRequest()
+        request.method = "GET"
+        request.META["QUERY_STRING"] = "foo=bar?bar=foo"
+        request.path = "/"
+
+        response = MalformedQueryStringMiddleware(request).process_request(request)
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.content, b"URL query string is malformed.")
+
+        # Encoded chars should be decoded
+        request.META["QUERY_STRING"] = "foo=bar%3Fbar=foo"
+
+        response = MalformedQueryStringMiddleware(request).process_request(request)
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.content, b"URL query string is malformed.")
+
+    def test_malformed_query_string_middleware_ignore_api_endpoint(self):
+        """
+        If the request path is an api endpoint, the middleware should ignore it.
+        """
+        request = HttpRequest()
+        request.method = "GET"
+        request.META["QUERY_STRING"] = "q=Hello?"
+        request.path = "/api/v1.0/search/"
+
+        response = MalformedQueryStringMiddleware(request).process_request(request)
+        self.assertIsNone(response)
+
+    def test_malformed_query_string_middleware_ignore_admin_endpoint(self):
+        """
+        If the request path is an admin endpoint, the middleware should ignore it.
+        """
+        request = HttpRequest()
+        request.method = "GET"
+        request.META["QUERY_STRING"] = "?placeholder_id=1&cms_path=/en/news/test/?edit"
+        request.path = "/en/admin/cms/page/add-plugin/"
+
+        response = MalformedQueryStringMiddleware(request).process_request(request)
+        self.assertIsNone(response)
+
+    def test_malformed_query_string_middleware_ignore_non_get_request(self):
+        """
+        If the request method is something else than GET,
+        the middleware should ignore it.
+        """
+        request = HttpRequest()
+        request.method = "POST"
+        request.META["QUERY_STRING"] = "q=Hello?"
+        request.path = "/api/v1.0/search/"
+
+        response = MalformedQueryStringMiddleware(request).process_request(request)
+        self.assertIsNone(response)

--- a/sites/funcampus/src/backend/funcampus/settings.py
+++ b/sites/funcampus/src/backend/funcampus/settings.py
@@ -258,6 +258,7 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
     }
 
     MIDDLEWARE = (
+        "base.middleware.MalformedQueryStringMiddleware",
         "richie.apps.core.cache.LimitBrowserCacheTTLHeaders",
         "cms.middleware.utils.ApphookReloadMiddleware",
         "django.middleware.security.SecurityMiddleware",


### PR DESCRIPTION
## Purpose

Some bots are spamming fun campus by producing urls with malformed query strings.

## Proposal

In order to prevent this spam, as it was done on FUN MOOC (PR #251 and #254), we implement a middleware in charge of detect query strings then raise a BadRequest exception if one is detected.

