### PR TITLE
🔖(ademe/demo/funcampus/funcorporate/funmooc) bump to next minor versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -672,11 +672,66 @@ workflows:
                 site: funcorporate
     funmooc:
         jobs:
-            - no-change:
+            - check-changelog:
+                filters:
+                    branches:
+                        ignore: main
+                name: check-changelog-funmooc
+                site: funmooc
+            - lint-changelog:
+                filters:
+                    branches:
+                        ignore: main
+                    tags:
+                        only: /^funmooc-.*/
+                name: lint-changelog--funmooc
+                site: funmooc
+            - build-front-production:
                 filters:
                     tags:
-                        only: /.*/
-                name: no-change-funmooc
+                        only: /^funmooc-.*/
+                name: build-front-production-funmooc
+                site: funmooc
+            - lint-front:
+                filters:
+                    tags:
+                        only: /^funmooc-.*/
+                name: lint-front-funmooc
+                requires:
+                    - build-front-production-funmooc
+                site: funmooc
+            - build-back:
+                filters:
+                    tags:
+                        only: /^funmooc-.*/
+                name: build-back-funmooc
+                site: funmooc
+            - lint-back:
+                filters:
+                    tags:
+                        only: /^funmooc-.*/
+                name: lint-back-funmooc
+                requires:
+                    - build-back-funmooc
+                site: funmooc
+            - test-back:
+                filters:
+                    tags:
+                        only: /^funmooc-.*/
+                name: test-back-funmooc
+                requires:
+                    - build-back-funmooc
+                site: funmooc
+            - hub:
+                filters:
+                    tags:
+                        only: /^funmooc-.*/
+                image_name: funmooc
+                name: hub-funmooc
+                requires:
+                    - lint-front-funmooc
+                    - lint-back-funmooc
+                site: funmooc
     site-factory:
         jobs:
             - lint-git:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -486,11 +486,66 @@ workflows:
                 - << pipeline.schedule.name >>
     demo:
         jobs:
-            - no-change:
+            - check-changelog:
+                filters:
+                    branches:
+                        ignore: main
+                name: check-changelog-demo
+                site: demo
+            - lint-changelog:
+                filters:
+                    branches:
+                        ignore: main
+                    tags:
+                        only: /^demo-.*/
+                name: lint-changelog--demo
+                site: demo
+            - build-front-production:
                 filters:
                     tags:
-                        only: /.*/
-                name: no-change-demo
+                        only: /^demo-.*/
+                name: build-front-production-demo
+                site: demo
+            - lint-front:
+                filters:
+                    tags:
+                        only: /^demo-.*/
+                name: lint-front-demo
+                requires:
+                    - build-front-production-demo
+                site: demo
+            - build-back:
+                filters:
+                    tags:
+                        only: /^demo-.*/
+                name: build-back-demo
+                site: demo
+            - lint-back:
+                filters:
+                    tags:
+                        only: /^demo-.*/
+                name: lint-back-demo
+                requires:
+                    - build-back-demo
+                site: demo
+            - test-back:
+                filters:
+                    tags:
+                        only: /^demo-.*/
+                name: test-back-demo
+                requires:
+                    - build-back-demo
+                site: demo
+            - hub:
+                filters:
+                    tags:
+                        only: /^demo-.*/
+                image_name: richie-demo
+                name: hub-demo
+                requires:
+                    - lint-front-demo
+                    - lint-back-demo
+                site: demo
     funcampus:
         jobs:
             - check-changelog:

--- a/sites/ademe/CHANGELOG.md
+++ b/sites/ademe/CHANGELOG.md
@@ -9,6 +9,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.23.0] - 2025-05-19
+
 ### Changed
 
 - Upgrade richie to 3.1.0
@@ -227,7 +229,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - First `ademe` image
 
-[unreleased]: https://github.com/openfun/fun-richie-site-factory/compare/ademe-0.22.0...HEAD
+[unreleased]: https://github.com/openfun/fun-richie-site-factory/compare/ademe-0.23.0...HEAD
+[0.23.0]: https://github.com/openfun/fun-richie-site-factory/compare/ademe-0.22.0...ademe-0.23.0
 [0.22.0]: https://github.com/openfun/fun-richie-site-factory/compare/ademe-0.21.1...ademe-0.22.0
 [0.21.1]: https://github.com/openfun/fun-richie-site-factory/compare/ademe-0.21.0...ademe-0.21.1
 [0.21.0]: https://github.com/openfun/fun-richie-site-factory/compare/ademe-0.20.1...ademe-0.21.0

--- a/sites/ademe/CHANGELOG.md
+++ b/sites/ademe/CHANGELOG.md
@@ -9,6 +9,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Upgrade richie to 3.1.0
+
 ## [0.22.0] - 2025-05-05
 
 ### Added

--- a/sites/ademe/requirements/base.txt
+++ b/sites/ademe/requirements/base.txt
@@ -8,5 +8,5 @@ dockerflow==2024.4.2
 factory-boy==3.3.3
 gunicorn==23.0.0
 psycopg2-binary==2.9.10
-richie==3.0.0
+richie==3.1.0
 sentry-sdk==2.24.1

--- a/sites/ademe/src/backend/ademe/__init__.py
+++ b/sites/ademe/src/backend/ademe/__init__.py
@@ -1,3 +1,3 @@
 """ademe application"""
 
-__version__ = "0.22.0"
+__version__ = "0.23.0"

--- a/sites/ademe/src/frontend/package.json
+++ b/sites/ademe/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ademe",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "description": "Richie-powered CMS for www.mooc-batiment-durable.fr",
   "scripts": {
     "build-sass": "sass scss/_main.scss ../backend/base/static/richie/css/main.css --load-path=node_modules",

--- a/sites/ademe/src/frontend/package.json
+++ b/sites/ademe/src/frontend/package.json
@@ -34,7 +34,7 @@
   },
   "homepage": "https://github.com/openfun/fun-richie-site-factory#readme",
   "dependencies": {
-    "richie-education": "3.0.0"
+    "richie-education": "3.1.0"
   },
   "devDependencies": {
     "@formatjs/cli": "6.6.2",

--- a/sites/ademe/src/frontend/yarn.lock
+++ b/sites/ademe/src/frontend/yarn.lock
@@ -9865,10 +9865,10 @@ reusify@^1.0.4:
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
   integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
 
-richie-education@3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/richie-education/-/richie-education-3.0.0.tgz#7aa8ac34da7fd0040e90cf0693443de4e3771554"
-  integrity sha512-fmSrU+/tUpkwGRDFCahsOYKVjWqbzjBlvB23/2lu4dKOJZabVjKQGRbYcAabnB24qHV/zNDDVT8s02ObO2e9iA==
+richie-education@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/richie-education/-/richie-education-3.1.0.tgz#ba3e842e8ae38f6db1adeaf18dacb87b85531709"
+  integrity sha512-myGVFbA9Idpi3CM/vqSNjBELwQIO8RhbJEjzZDLyD2ZVmrlNGjGidxhA5TMNpDvH7Fh5rJST2q33tq4lQLwYKw==
   dependencies:
     "@babel/core" "7.26.10"
     "@babel/plugin-syntax-dynamic-import" "7.8.3"

--- a/sites/demo/CHANGELOG.md
+++ b/sites/demo/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.28.0] - 2025-05-19
+
 ### Changed
 
 - Upgrade richie to 3.1.0
@@ -358,7 +360,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 First demo image for richie to 2.0.0-beta.7
 
-[unreleased]: https://github.com/openfun/fun-richie-site-factory/compare/demo-1.27.1...HEAD
+[unreleased]: https://github.com/openfun/fun-richie-site-factory/compare/demo-1.28.0...HEAD
+[1.28.0]: https://github.com/openfun/fun-richie-site-factory/compare/demo-1.27.1...demo-1.28.0
 [1.27.1]: https://github.com/openfun/fun-richie-site-factory/compare/demo-1.27.0...demo-1.27.1
 [1.27.0]: https://github.com/openfun/fun-richie-site-factory/compare/demo-1.26.0...demo-1.27.0
 [1.26.0]: https://github.com/openfun/fun-richie-site-factory/compare/demo-1.25.0...demo-1.26.0

--- a/sites/demo/CHANGELOG.md
+++ b/sites/demo/CHANGELOG.md
@@ -10,7 +10,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
-- Upgrade richie to 3.0.0
+- Upgrade richie to 3.1.0
 - Migrate to new STORAGES settings
 
 ## [1.27.1] - 2023-08-30

--- a/sites/demo/requirements/base.txt
+++ b/sites/demo/requirements/base.txt
@@ -8,5 +8,5 @@ dockerflow==2024.4.2
 factory-boy==3.3.3
 gunicorn==23.0.0
 psycopg2-binary==2.9.10
-richie==3.0.0
+richie==3.1.0
 sentry-sdk==2.24.1

--- a/sites/demo/src/backend/demo/__init__.py
+++ b/sites/demo/src/backend/demo/__init__.py
@@ -1,3 +1,3 @@
 """demo application"""
 
-__version__ = "1.27.1"
+__version__ = "1.28.0"

--- a/sites/demo/src/frontend/package.json
+++ b/sites/demo/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "richie",
-  "version": "1.27.1",
+  "version": "1.28.0",
   "description": "Richie demo site on https://demo.richie.education",
   "scripts": {
     "build-ts": "tsc --noEmit && webpack --config node_modules/richie-education/webpack.config.js --output-path ../backend/base/static/richie/js/build --env richie-dependent-build --env richie-settings=overrides.json",

--- a/sites/demo/src/frontend/package.json
+++ b/sites/demo/src/frontend/package.json
@@ -33,7 +33,7 @@
   },
   "homepage": "https://github.com/openfun/fun-richie-site-factory#readme",
   "dependencies": {
-    "richie-education": "3.0.0"
+    "richie-education": "3.1.0"
   },
   "devDependencies": {
     "@formatjs/cli": "6.6.2",

--- a/sites/demo/src/frontend/yarn.lock
+++ b/sites/demo/src/frontend/yarn.lock
@@ -8981,10 +8981,10 @@ reusify@^1.0.4:
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.1.0.tgz#0fe13b9522e1473f51b558ee796e08f11f9b489f"
   integrity sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==
 
-richie-education@3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/richie-education/-/richie-education-3.0.0.tgz#7aa8ac34da7fd0040e90cf0693443de4e3771554"
-  integrity sha512-fmSrU+/tUpkwGRDFCahsOYKVjWqbzjBlvB23/2lu4dKOJZabVjKQGRbYcAabnB24qHV/zNDDVT8s02ObO2e9iA==
+richie-education@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/richie-education/-/richie-education-3.1.0.tgz#ba3e842e8ae38f6db1adeaf18dacb87b85531709"
+  integrity sha512-myGVFbA9Idpi3CM/vqSNjBELwQIO8RhbJEjzZDLyD2ZVmrlNGjGidxhA5TMNpDvH7Fh5rJST2q33tq4lQLwYKw==
   dependencies:
     "@babel/core" "7.26.10"
     "@babel/plugin-syntax-dynamic-import" "7.8.3"

--- a/sites/funcampus/CHANGELOG.md
+++ b/sites/funcampus/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Upgrade richie to 3.1.0
+
 ## [1.27.0] - 2025-05-05
 
 ### Added

--- a/sites/funcampus/CHANGELOG.md
+++ b/sites/funcampus/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.28.0] - 2025-05-19
+
 ### Changed
 
 - Upgrade richie to 3.1.0
@@ -334,7 +336,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - First `funcampus` image
 
-[unreleased]: https://github.com/openfun/fun-richie-site-factory/compare/funcampus-1.27.0...HEAD
+[unreleased]: https://github.com/openfun/fun-richie-site-factory/compare/funcampus-1.28.0...HEAD
+[1.28.0]: https://github.com/openfun/fun-richie-site-factory/compare/funcampus-1.27.0...funcampus-1.28.0
 [1.27.0]: https://github.com/openfun/fun-richie-site-factory/compare/funcampus-1.26.0...funcampus-1.27.0
 [1.26.0]: https://github.com/openfun/fun-richie-site-factory/compare/funcampus-1.25.0...funcampus-1.26.0
 [1.25.0]: https://github.com/openfun/fun-richie-site-factory/compare/funcampus-1.24.0...funcampus-1.25.0

--- a/sites/funcampus/requirements/base.txt
+++ b/sites/funcampus/requirements/base.txt
@@ -8,7 +8,7 @@ dockerflow==2024.4.2
 factory-boy==3.3.3
 gunicorn==23.0.0
 psycopg2-binary==2.9.10
-richie==3.0.0
+richie==3.1.0
 sentry-sdk==2.24.1
 
 # Google sheet importer

--- a/sites/funcampus/src/backend/funcampus/__init__.py
+++ b/sites/funcampus/src/backend/funcampus/__init__.py
@@ -1,3 +1,3 @@
 """funcampus application"""
 
-__version__ = "1.27.0"
+__version__ = "1.28.0"

--- a/sites/funcampus/src/frontend/package.json
+++ b/sites/funcampus/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "funcampus",
-  "version": "1.27.0",
+  "version": "1.28.0",
   "description": "The future www.fun-campus.fr website based on https://github.com/openfun/richie",
   "scripts": {
     "build-ts": "tsc --noEmit && webpack --config node_modules/richie-education/webpack.config.js --output-path ../backend/base/static/richie/js/build --env richie-dependent-build --env richie-settings=overrides.json",

--- a/sites/funcampus/src/frontend/package.json
+++ b/sites/funcampus/src/frontend/package.json
@@ -34,7 +34,7 @@
   },
   "homepage": "https://github.com/openfun/fun-richie-site-factory#readme",
   "dependencies": {
-    "richie-education": "3.0.0"
+    "richie-education": "3.1.0"
   },
   "devDependencies": {
     "@formatjs/cli": "6.6.2",

--- a/sites/funcampus/src/frontend/yarn.lock
+++ b/sites/funcampus/src/frontend/yarn.lock
@@ -8981,10 +8981,10 @@ reusify@^1.0.4:
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.1.0.tgz#0fe13b9522e1473f51b558ee796e08f11f9b489f"
   integrity sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==
 
-richie-education@3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/richie-education/-/richie-education-3.0.0.tgz#7aa8ac34da7fd0040e90cf0693443de4e3771554"
-  integrity sha512-fmSrU+/tUpkwGRDFCahsOYKVjWqbzjBlvB23/2lu4dKOJZabVjKQGRbYcAabnB24qHV/zNDDVT8s02ObO2e9iA==
+richie-education@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/richie-education/-/richie-education-3.1.0.tgz#ba3e842e8ae38f6db1adeaf18dacb87b85531709"
+  integrity sha512-myGVFbA9Idpi3CM/vqSNjBELwQIO8RhbJEjzZDLyD2ZVmrlNGjGidxhA5TMNpDvH7Fh5rJST2q33tq4lQLwYKw==
   dependencies:
     "@babel/core" "7.26.10"
     "@babel/plugin-syntax-dynamic-import" "7.8.3"

--- a/sites/funcorporate/CHANGELOG.md
+++ b/sites/funcorporate/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.28.0] - 2025-05-19
+
 ### Changed
 
 - Upgrade richie to 3.1.0
@@ -404,7 +406,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Update project urls to add styleguide and account views.
 - Update layout color theme and logo to fit fun-corporate mockups.
 
-[unreleased]: https://github.com/openfun/fun-richie-site-factory/compare/funcorporate-1.27.0...HEAD
+[unreleased]: https://github.com/openfun/fun-richie-site-factory/compare/funcorporate-1.28.0...HEAD
+[1.28.0]: https://github.com/openfun/fun-richie-site-factory/compare/funcorporate-1.27.0...funcorporate-1.28.0
 [1.27.0]: https://github.com/openfun/fun-richie-site-factory/compare/funcorporate-1.26.1...funcorporate-1.27.0
 [1.26.1]: https://github.com/openfun/fun-richie-site-factory/compare/funcorporate-1.26.0...funcorporate-1.26.1
 [1.26.0]: https://github.com/openfun/fun-richie-site-factory/compare/funcorporate-1.25.0...funcorporate-1.26.0

--- a/sites/funcorporate/CHANGELOG.md
+++ b/sites/funcorporate/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Upgrade richie to 3.1.0
+
 ## [1.27.0] - 2025-05-05
 
 ### Added

--- a/sites/funcorporate/requirements/base.txt
+++ b/sites/funcorporate/requirements/base.txt
@@ -8,7 +8,7 @@ dockerflow==2024.4.2
 factory-boy==3.3.3
 gunicorn==23.0.0
 psycopg2-binary==2.9.10
-richie==3.0.0
+richie==3.1.0
 sentry-sdk==2.24.1
 
 # Google sheet importer

--- a/sites/funcorporate/src/backend/funcorporate/__init__.py
+++ b/sites/funcorporate/src/backend/funcorporate/__init__.py
@@ -1,3 +1,3 @@
 """FUN Corporate application"""
 
-__version__ = "1.27.0"
+__version__ = "1.28.0"

--- a/sites/funcorporate/src/frontend/package.json
+++ b/sites/funcorporate/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "funcorporate",
-  "version": "1.27.0",
+  "version": "1.28.0",
   "description": "The future www.fun-corporate.fr website based on https://github.com/openfun/richie",
   "scripts": {
     "build-ts": "tsc --noEmit && webpack --config node_modules/richie-education/webpack.config.js --output-path ../backend/base/static/richie/js/build --env richie-dependent-build --env richie-settings=overrides.json",

--- a/sites/funcorporate/src/frontend/package.json
+++ b/sites/funcorporate/src/frontend/package.json
@@ -34,7 +34,7 @@
   },
   "homepage": "https://github.com/openfun/fun-richie-site-factory#readme",
   "dependencies": {
-    "richie-education": "3.0.0"
+    "richie-education": "3.1.0"
   },
   "devDependencies": {
     "@formatjs/cli": "6.6.2",

--- a/sites/funcorporate/src/frontend/yarn.lock
+++ b/sites/funcorporate/src/frontend/yarn.lock
@@ -8981,10 +8981,10 @@ reusify@^1.0.4:
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.1.0.tgz#0fe13b9522e1473f51b558ee796e08f11f9b489f"
   integrity sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==
 
-richie-education@3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/richie-education/-/richie-education-3.0.0.tgz#7aa8ac34da7fd0040e90cf0693443de4e3771554"
-  integrity sha512-fmSrU+/tUpkwGRDFCahsOYKVjWqbzjBlvB23/2lu4dKOJZabVjKQGRbYcAabnB24qHV/zNDDVT8s02ObO2e9iA==
+richie-education@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/richie-education/-/richie-education-3.1.0.tgz#ba3e842e8ae38f6db1adeaf18dacb87b85531709"
+  integrity sha512-myGVFbA9Idpi3CM/vqSNjBELwQIO8RhbJEjzZDLyD2ZVmrlNGjGidxhA5TMNpDvH7Fh5rJST2q33tq4lQLwYKw==
   dependencies:
     "@babel/core" "7.26.10"
     "@babel/plugin-syntax-dynamic-import" "7.8.3"

--- a/sites/funmooc/CHANGELOG.md
+++ b/sites/funmooc/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.43.0] - 2025-05-19
+
 ### Changed
 
 - Upgrade richie to 3.1.0
@@ -823,7 +825,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Static and media files are stored in AWS S3 buckets and distributed _via_
   Amazon CloudFront
 
-[unreleased]: https://github.com/openfun/fun-richie-site-factory/compare/funmooc-1.42.0...HEAD
+[unreleased]: https://github.com/openfun/fun-richie-site-factory/compare/funmooc-1.43.0...HEAD
+[1.43.0]: https://github.com/openfun/fun-richie-site-factory/compare/funmooc-1.42.0...funmooc-1.43.0
 [1.42.0]: https://github.com/openfun/fun-richie-site-factory/compare/funmooc-1.42.0-beta.2...funmooc-1.42.0
 [1.42.0-beta.2]: https://github.com/openfun/fun-richie-site-factory/compare/funmooc-1.42.0-beta.1...funmooc-1.42.0-beta.2
 [1.42.0-beta.1]: https://github.com/openfun/fun-richie-site-factory/compare/funmooc-1.42.0-beta.0...funmooc-1.42.0-beta.1

--- a/sites/funmooc/CHANGELOG.md
+++ b/sites/funmooc/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Upgrade richie to 3.1.0
 - Upgrade all deps
 
 ## [1.42.0] - 2025-04-08

--- a/sites/funmooc/requirements/base.txt
+++ b/sites/funmooc/requirements/base.txt
@@ -8,5 +8,5 @@ dockerflow==2024.4.2
 factory-boy==3.3.3
 gunicorn==23.0.0
 psycopg2-binary==2.9.10
-richie==3.0.0
+richie==3.1.0
 sentry-sdk==2.24.1

--- a/sites/funmooc/src/backend/funmooc/__init__.py
+++ b/sites/funmooc/src/backend/funmooc/__init__.py
@@ -1,3 +1,3 @@
 """funmooc application"""
 
-__version__ = "1.42.0"
+__version__ = "1.43.0"

--- a/sites/funmooc/src/frontend/package.json
+++ b/sites/funmooc/src/frontend/package.json
@@ -36,7 +36,7 @@
   },
   "homepage": "https://github.com/openfun/fun-richie-site-factory#readme",
   "dependencies": {
-    "richie-education": "3.0.0",
+    "richie-education": "3.1.0",
     "tarteaucitronjs": "1.14.0"
   },
   "devDependencies": {

--- a/sites/funmooc/src/frontend/package.json
+++ b/sites/funmooc/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "funmooc",
-  "version": "1.42.0",
+  "version": "1.43.0",
   "description": "Richie-powered CMS for fun-mooc.fr",
   "scripts": {
     "build-sass": "sass scss/_main.scss ../backend/base/static/richie/css/main.css --load-path=node_modules",

--- a/sites/funmooc/src/frontend/yarn.lock
+++ b/sites/funmooc/src/frontend/yarn.lock
@@ -10257,10 +10257,10 @@ reusify@^1.0.4:
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
   integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
 
-richie-education@3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/richie-education/-/richie-education-3.0.0.tgz#7aa8ac34da7fd0040e90cf0693443de4e3771554"
-  integrity sha512-fmSrU+/tUpkwGRDFCahsOYKVjWqbzjBlvB23/2lu4dKOJZabVjKQGRbYcAabnB24qHV/zNDDVT8s02ObO2e9iA==
+richie-education@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/richie-education/-/richie-education-3.1.0.tgz#ba3e842e8ae38f6db1adeaf18dacb87b85531709"
+  integrity sha512-myGVFbA9Idpi3CM/vqSNjBELwQIO8RhbJEjzZDLyD2ZVmrlNGjGidxhA5TMNpDvH7Fh5rJST2q33tq4lQLwYKw==
   dependencies:
     "@babel/core" "7.26.10"
     "@babel/plugin-syntax-dynamic-import" "7.8.3"


### PR DESCRIPTION
## Ademe

### Changed

- Upgrade richie to 3.1.0

## Demo

### Changed

- Upgrade richie to 3.1.0
- Upgrade richie to 3.0.0
- Migrate to new STORAGES settings

## Funcampus

### Changed

- Upgrade richie to 3.1.0

## Funcorporate

### Changed

- Upgrade richie to 3.1.0

## Funmooc

### Changed

- Upgrade richie to 3.1.0
- Upgrade all deps