### PR TITLE
🧱(funcorporate) migrate media storage to Scaleway and drop CDN static proxy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -398,11 +398,66 @@ version: 2.1
 workflows:
     ademe:
         jobs:
-            - no-change:
+            - check-changelog:
+                filters:
+                    branches:
+                        ignore: main
+                name: check-changelog-ademe
+                site: ademe
+            - lint-changelog:
+                filters:
+                    branches:
+                        ignore: main
+                    tags:
+                        only: /^ademe-.*/
+                name: lint-changelog--ademe
+                site: ademe
+            - build-front-production:
                 filters:
                     tags:
-                        only: /.*/
-                name: no-change-ademe
+                        only: /^ademe-.*/
+                name: build-front-production-ademe
+                site: ademe
+            - lint-front:
+                filters:
+                    tags:
+                        only: /^ademe-.*/
+                name: lint-front-ademe
+                requires:
+                    - build-front-production-ademe
+                site: ademe
+            - build-back:
+                filters:
+                    tags:
+                        only: /^ademe-.*/
+                name: build-back-ademe
+                site: ademe
+            - lint-back:
+                filters:
+                    tags:
+                        only: /^ademe-.*/
+                name: lint-back-ademe
+                requires:
+                    - build-back-ademe
+                site: ademe
+            - test-back:
+                filters:
+                    tags:
+                        only: /^ademe-.*/
+                name: test-back-ademe
+                requires:
+                    - build-back-ademe
+                site: ademe
+            - hub:
+                filters:
+                    tags:
+                        only: /^ademe-.*/
+                image_name: ademe
+                name: hub-ademe
+                requires:
+                    - lint-front-ademe
+                    - lint-back-ademe
+                site: ademe
     canary:
         jobs:
             - hub-canary:
@@ -431,32 +486,252 @@ workflows:
                 - << pipeline.schedule.name >>
     demo:
         jobs:
-            - no-change:
+            - check-changelog:
+                filters:
+                    branches:
+                        ignore: main
+                name: check-changelog-demo
+                site: demo
+            - lint-changelog:
+                filters:
+                    branches:
+                        ignore: main
+                    tags:
+                        only: /^demo-.*/
+                name: lint-changelog--demo
+                site: demo
+            - build-front-production:
                 filters:
                     tags:
-                        only: /.*/
-                name: no-change-demo
+                        only: /^demo-.*/
+                name: build-front-production-demo
+                site: demo
+            - lint-front:
+                filters:
+                    tags:
+                        only: /^demo-.*/
+                name: lint-front-demo
+                requires:
+                    - build-front-production-demo
+                site: demo
+            - build-back:
+                filters:
+                    tags:
+                        only: /^demo-.*/
+                name: build-back-demo
+                site: demo
+            - lint-back:
+                filters:
+                    tags:
+                        only: /^demo-.*/
+                name: lint-back-demo
+                requires:
+                    - build-back-demo
+                site: demo
+            - test-back:
+                filters:
+                    tags:
+                        only: /^demo-.*/
+                name: test-back-demo
+                requires:
+                    - build-back-demo
+                site: demo
+            - hub:
+                filters:
+                    tags:
+                        only: /^demo-.*/
+                image_name: richie-demo
+                name: hub-demo
+                requires:
+                    - lint-front-demo
+                    - lint-back-demo
+                site: demo
     funcampus:
         jobs:
-            - no-change:
+            - check-changelog:
+                filters:
+                    branches:
+                        ignore: main
+                name: check-changelog-funcampus
+                site: funcampus
+            - lint-changelog:
+                filters:
+                    branches:
+                        ignore: main
+                    tags:
+                        only: /^funcampus-.*/
+                name: lint-changelog--funcampus
+                site: funcampus
+            - build-front-production:
                 filters:
                     tags:
-                        only: /.*/
-                name: no-change-funcampus
+                        only: /^funcampus-.*/
+                name: build-front-production-funcampus
+                site: funcampus
+            - lint-front:
+                filters:
+                    tags:
+                        only: /^funcampus-.*/
+                name: lint-front-funcampus
+                requires:
+                    - build-front-production-funcampus
+                site: funcampus
+            - build-back:
+                filters:
+                    tags:
+                        only: /^funcampus-.*/
+                name: build-back-funcampus
+                site: funcampus
+            - lint-back:
+                filters:
+                    tags:
+                        only: /^funcampus-.*/
+                name: lint-back-funcampus
+                requires:
+                    - build-back-funcampus
+                site: funcampus
+            - test-back:
+                filters:
+                    tags:
+                        only: /^funcampus-.*/
+                name: test-back-funcampus
+                requires:
+                    - build-back-funcampus
+                site: funcampus
+            - hub:
+                filters:
+                    tags:
+                        only: /^funcampus-.*/
+                image_name: funcampus
+                name: hub-funcampus
+                requires:
+                    - lint-front-funcampus
+                    - lint-back-funcampus
+                site: funcampus
     funcorporate:
         jobs:
-            - no-change:
+            - check-changelog:
+                filters:
+                    branches:
+                        ignore: main
+                name: check-changelog-funcorporate
+                site: funcorporate
+            - lint-changelog:
+                filters:
+                    branches:
+                        ignore: main
+                    tags:
+                        only: /^funcorporate-.*/
+                name: lint-changelog--funcorporate
+                site: funcorporate
+            - build-front-production:
                 filters:
                     tags:
-                        only: /.*/
-                name: no-change-funcorporate
+                        only: /^funcorporate-.*/
+                name: build-front-production-funcorporate
+                site: funcorporate
+            - lint-front:
+                filters:
+                    tags:
+                        only: /^funcorporate-.*/
+                name: lint-front-funcorporate
+                requires:
+                    - build-front-production-funcorporate
+                site: funcorporate
+            - build-back:
+                filters:
+                    tags:
+                        only: /^funcorporate-.*/
+                name: build-back-funcorporate
+                site: funcorporate
+            - lint-back:
+                filters:
+                    tags:
+                        only: /^funcorporate-.*/
+                name: lint-back-funcorporate
+                requires:
+                    - build-back-funcorporate
+                site: funcorporate
+            - test-back:
+                filters:
+                    tags:
+                        only: /^funcorporate-.*/
+                name: test-back-funcorporate
+                requires:
+                    - build-back-funcorporate
+                site: funcorporate
+            - hub:
+                filters:
+                    tags:
+                        only: /^funcorporate-.*/
+                image_name: funcorporate
+                name: hub-funcorporate
+                requires:
+                    - lint-front-funcorporate
+                    - lint-back-funcorporate
+                site: funcorporate
     funmooc:
         jobs:
-            - no-change:
+            - check-changelog:
+                filters:
+                    branches:
+                        ignore: main
+                name: check-changelog-funmooc
+                site: funmooc
+            - lint-changelog:
+                filters:
+                    branches:
+                        ignore: main
+                    tags:
+                        only: /^funmooc-.*/
+                name: lint-changelog--funmooc
+                site: funmooc
+            - build-front-production:
                 filters:
                     tags:
-                        only: /.*/
-                name: no-change-funmooc
+                        only: /^funmooc-.*/
+                name: build-front-production-funmooc
+                site: funmooc
+            - lint-front:
+                filters:
+                    tags:
+                        only: /^funmooc-.*/
+                name: lint-front-funmooc
+                requires:
+                    - build-front-production-funmooc
+                site: funmooc
+            - build-back:
+                filters:
+                    tags:
+                        only: /^funmooc-.*/
+                name: build-back-funmooc
+                site: funmooc
+            - lint-back:
+                filters:
+                    tags:
+                        only: /^funmooc-.*/
+                name: lint-back-funmooc
+                requires:
+                    - build-back-funmooc
+                site: funmooc
+            - test-back:
+                filters:
+                    tags:
+                        only: /^funmooc-.*/
+                name: test-back-funmooc
+                requires:
+                    - build-back-funmooc
+                site: funmooc
+            - hub:
+                filters:
+                    tags:
+                        only: /^funmooc-.*/
+                image_name: funmooc
+                name: hub-funmooc
+                requires:
+                    - lint-front-funmooc
+                    - lint-back-funmooc
+                site: funmooc
     site-factory:
         jobs:
             - lint-git:

--- a/docs/scw.md
+++ b/docs/scw.md
@@ -122,7 +122,7 @@ Django application to access to those buckets and Edge Services endpoints.
 The environment variables use the `AWS` prefix, as required by [django-storages](https://django-storages.readthedocs.io/en/latest/backends/s3_compatible/scaleway.html), even though Scaleway is being used.
 The following environment variables should be defined:
 
-- `DJANGO_CDN_DOMAIN`
+- `DJANGO_AWS_S3_CUSTOM_DOMAIN`
 - `DJANGO_AWS_ACCESS_KEY_ID`
 - `DJANGO_AWS_SECRET_ACCESS_KEY`
 

--- a/scw/s3.tf
+++ b/scw/s3.tf
@@ -37,15 +37,28 @@ resource "scaleway_object_bucket_acl" "richie_media_acl" {
   acl    = "private"
 }
 
-
-# Defines a user (here an application) that should be able to write to the S3 bucket
+# Defines an application that should have access to the S3 bucket
 resource "scaleway_iam_application" "richie_application" {
   name = "${terraform.workspace}-${var.site}"
   description = "Richie application for the media bucket"
 }
 
+# Defines a policy so that the application have full access to Object Storage
+resource "scaleway_iam_policy" "application_object_full_access" {
+  name           = "${terraform.workspace}-${var.site}-media"
+  description    = "Full access to object storage for application"
+  application_id = scaleway_iam_application.richie_application.id
+
+  rule {
+    project_ids          = [var.scw_project_id]
+    permission_set_names = ["ObjectStorageFullAccess"]
+  }
+}
+
+# Defines an API key for the application
 resource "scaleway_iam_api_key" "richie_api_key" {
   application_id = scaleway_iam_application.richie_application.id
+  default_project_id = var.scw_project_id
 }
 
 

--- a/sites/ademe/CHANGELOG.md
+++ b/sites/ademe/CHANGELOG.md
@@ -9,6 +9,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Change settings to migrate media storage from AWS to Scaleway
+
 ## [0.23.2] - 2025-05-22
 
 ### Fixed

--- a/sites/ademe/scw/config.tfvars
+++ b/sites/ademe/scw/config.tfvars
@@ -1,0 +1,1 @@
+site = "ademe"

--- a/sites/ademe/src/backend/ademe/settings.py
+++ b/sites/ademe/src/backend/ademe/settings.py
@@ -1081,36 +1081,54 @@ class Production(Base):
     SECURE_CONTENT_TYPE_NOSNIFF = True
     SESSION_COOKIE_SECURE = True
 
-    STORAGES = {
-        "default": {
-            "BACKEND": "richie.apps.core.storage.MediaStorage",
+    # Using the S3Storage to be able to change the custom domain for media files without
+    # interfering with static files. Using the CDNManifestStaticFilesStorage with an
+    # undefined CDN_DOMAIN to use the custom `post_process` method.
+    STORAGES = values.DictValue(
+        {
+            "default": {
+                "BACKEND": values.Value(
+                    "storages.backends.s3.S3Storage",
+                    environ_name="STORAGES_DEFAULT_BACKEND",
+                ),
+                "OPTIONS": values.DictValue(
+                    {},
+                    environ_name="STORAGES_DEFAULT_OPTIONS",
+                ),
+            },
+            "staticfiles": {
+                "BACKEND": values.Value(
+                    "richie.apps.core.storage.CDNManifestStaticFilesStorage",
+                    environ_name="STORAGES_STATICFILES_BACKEND",
+                ),
+                "OPTIONS": values.DictValue(
+                    {},
+                    environ_name="STORAGES_STATICFILES_OPTIONS",
+                ),
+            },
         },
-        "staticfiles": {
-            "BACKEND": "richie.apps.core.storage.CDNManifestStaticFilesStorage",
-        },
-    }
+        environ_name="STORAGES",
+    )
     AWS_DEFAULT_ACL = None
     AWS_LOCATION = "media"
 
     AWS_ACCESS_KEY_ID = values.SecretValue()
     AWS_SECRET_ACCESS_KEY = values.SecretValue()
+    AWS_S3_REGION_NAME = values.Value("fr-par")
+    AWS_S3_ENDPOINT_URL = values.Value("https://s3.fr-par.scw.cloud")
 
     AWS_S3_OBJECT_PARAMETERS = {
         "Expires": "Thu, 31 Dec 2099 20:00:00 GMT",
         "CacheControl": "max-age=94608000",
     }
 
-    AWS_S3_REGION_NAME = values.Value("eu-west-1")
+    # CDN domain used to serve media files through the S3Storage
+    AWS_S3_CUSTOM_DOMAIN = values.Value(None)
+    AWS_STORAGE_BUCKET_NAME = values.Value("production-ademe-media")
+    AWS_S3_FILE_OVERWRITE = values.Value(False)
 
-    AWS_MEDIA_BUCKET_NAME = values.Value("production-ademe-media")
-
-    # CDN domain for static/media urls. It is passed to the frontend to load built chunks
-    CDN_DOMAIN = values.Value()
-
-    @property
-    def TEXT_CKEDITOR_BASE_PATH(self):  # pylint: disable=invalid-name
-        """Configure CKEditor with an absolute url as base path to point to CloudFront."""
-        return f"//{self.CDN_DOMAIN}/static/djangocms_text_ckeditor/ckeditor/"
+    # CDN domain for static urls. It is passed to the frontend to load built chunks.
+    CDN_DOMAIN = values.Value(None)
 
 
 class Feature(Production):
@@ -1120,7 +1138,7 @@ class Feature(Production):
     nota bene: it should inherit from the Production environment.
     """
 
-    AWS_MEDIA_BUCKET_NAME = values.Value("feature-ademe-media")
+    AWS_STORAGE_BUCKET_NAME = values.Value("feature-ademe-media")
 
 
 class Staging(Production):
@@ -1130,7 +1148,7 @@ class Staging(Production):
     nota bene: it should inherit from the Production environment.
     """
 
-    AWS_MEDIA_BUCKET_NAME = values.Value("staging-ademe-media")
+    AWS_STORAGE_BUCKET_NAME = values.Value("staging-ademe-media")
 
 
 class PreProduction(Production):
@@ -1140,4 +1158,4 @@ class PreProduction(Production):
     nota bene: it should inherit from the Production environment.
     """
 
-    AWS_MEDIA_BUCKET_NAME = values.Value("preprod-ademe-media")
+    AWS_STORAGE_BUCKET_NAME = values.Value("preprod-ademe-media")

--- a/sites/demo/CHANGELOG.md
+++ b/sites/demo/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Change settings to migrate media storage from AWS to Scaleway
+
 ## [1.28.2] - 2025-05-22
 
 ### Fixed

--- a/sites/demo/scw/config.tfvars
+++ b/sites/demo/scw/config.tfvars
@@ -1,0 +1,3 @@
+site = "demo"
+
+media_expiration = 2

--- a/sites/demo/src/backend/demo/settings.py
+++ b/sites/demo/src/backend/demo/settings.py
@@ -758,36 +758,55 @@ class Production(Base):
     SECURE_CONTENT_TYPE_NOSNIFF = True
     SESSION_COOKIE_SECURE = True
 
-    STORAGES = {
-        "default": {
-            "BACKEND": "richie.apps.core.storage.MediaStorage",
+    # Using the S3Storage to be able to change the custom domain for media files without
+    # interfering with static files. Using the CDNManifestStaticFilesStorage with an
+    # undefined CDN_DOMAIN to use the custom `post_process` method.
+    STORAGES = values.DictValue(
+        {
+            "default": {
+                "BACKEND": values.Value(
+                    "storages.backends.s3.S3Storage",
+                    environ_name="STORAGES_DEFAULT_BACKEND",
+                ),
+                "OPTIONS": values.DictValue(
+                    {},
+                    environ_name="STORAGES_DEFAULT_OPTIONS",
+                ),
+            },
+            "staticfiles": {
+                "BACKEND": values.Value(
+                    "richie.apps.core.storage.CDNManifestStaticFilesStorage",
+                    environ_name="STORAGES_STATICFILES_BACKEND",
+                ),
+                "OPTIONS": values.DictValue(
+                    {},
+                    environ_name="STORAGES_STATICFILES_OPTIONS",
+                ),
+            },
         },
-        "staticfiles": {
-            "BACKEND": "richie.apps.core.storage.CDNManifestStaticFilesStorage",
-        },
-    }
+        environ_name="STORAGES",
+    )
+
     AWS_DEFAULT_ACL = None
     AWS_LOCATION = "media"
 
     AWS_ACCESS_KEY_ID = values.SecretValue()
     AWS_SECRET_ACCESS_KEY = values.SecretValue()
+    AWS_S3_REGION_NAME = values.Value("fr-par")
+    AWS_S3_ENDPOINT_URL = values.Value("https://s3.fr-par.scw.cloud")
 
     AWS_S3_OBJECT_PARAMETERS = {
         "Expires": "Thu, 31 Dec 2099 20:00:00 GMT",
         "CacheControl": "max-age=94608000",
     }
 
-    AWS_S3_REGION_NAME = values.Value("eu-west-1")
+    # CDN domain used to serve media files through the S3Storage
+    AWS_S3_CUSTOM_DOMAIN = values.Value(None)
+    AWS_STORAGE_BUCKET_NAME = values.Value("production-richie-media")
+    AWS_S3_FILE_OVERWRITE = values.Value(False)
 
-    AWS_MEDIA_BUCKET_NAME = values.Value("production-richie-media")
-
-    # CDN domain for static/media urls. It is passed to the frontend to load built chunks
+    # CDN domain for static urls. It is passed to the frontend to load built chunks.
     CDN_DOMAIN = values.Value()
-
-    @property
-    def TEXT_CKEDITOR_BASE_PATH(self):  # pylint: disable=invalid-name
-        """Configure CKEditor with an absolute url as base path to point to CloudFront."""
-        return f"//{self.CDN_DOMAIN}/static/djangocms_text_ckeditor/ckeditor/"
 
 
 class Feature(Production):
@@ -797,7 +816,7 @@ class Feature(Production):
     nota bene: it should inherit from the Production environment.
     """
 
-    AWS_MEDIA_BUCKET_NAME = values.Value("feature-richie-media")
+    AWS_STORAGE_BUCKET_NAME = values.Value("feature-richie-media")
 
 
 class Staging(Production):
@@ -807,7 +826,7 @@ class Staging(Production):
     nota bene: it should inherit from the Production environment.
     """
 
-    AWS_MEDIA_BUCKET_NAME = values.Value("staging-richie-media")
+    AWS_STORAGE_BUCKET_NAME = values.Value("staging-richie-media")
 
 
 class PreProduction(Production):
@@ -817,4 +836,4 @@ class PreProduction(Production):
     nota bene: it should inherit from the Production environment.
     """
 
-    AWS_MEDIA_BUCKET_NAME = values.Value("preprod-richie-media")
+    AWS_STORAGE_BUCKET_NAME = values.Value("preprod-richie-media")

--- a/sites/funcampus/CHANGELOG.md
+++ b/sites/funcampus/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Change settings to migrate media storage from AWS to Scaleway
+
 ## [1.28.2] - 2025-05-22
 
 ### Fixed

--- a/sites/funcampus/scw/config.tfvars
+++ b/sites/funcampus/scw/config.tfvars
@@ -1,0 +1,1 @@
+site = "funcampus"

--- a/sites/funcorporate/CHANGELOG.md
+++ b/sites/funcorporate/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Change settings to migrate media storage from AWS to Scaleway
+
 ## [1.28.2] - 2025-05-22
 
 ### Fixed

--- a/sites/funcorporate/scw/config.tfvars
+++ b/sites/funcorporate/scw/config.tfvars
@@ -1,0 +1,1 @@
+site = "funcorporate"

--- a/sites/funcorporate/src/backend/funcorporate/settings.py
+++ b/sites/funcorporate/src/backend/funcorporate/settings.py
@@ -886,36 +886,54 @@ class Production(Base):
     SECURE_CONTENT_TYPE_NOSNIFF = True
     SESSION_COOKIE_SECURE = True
 
-    STORAGES = {
-        "default": {
-            "BACKEND": "richie.apps.core.storage.MediaStorage",
+    # Using the S3Storage to be able to change the custom domain for media files without
+    # interfering with static files. Using the CDNManifestStaticFilesStorage with an
+    # undefined CDN_DOMAIN to use the custom `post_process` method.
+    STORAGES = values.DictValue(
+        {
+            "default": {
+                "BACKEND": values.Value(
+                    "storages.backends.s3.S3Storage",
+                    environ_name="STORAGES_DEFAULT_BACKEND",
+                ),
+                "OPTIONS": values.DictValue(
+                    {},
+                    environ_name="STORAGES_DEFAULT_OPTIONS",
+                ),
+            },
+            "staticfiles": {
+                "BACKEND": values.Value(
+                    "richie.apps.core.storage.CDNManifestStaticFilesStorage",
+                    environ_name="STORAGES_STATICFILES_BACKEND",
+                ),
+                "OPTIONS": values.DictValue(
+                    {},
+                    environ_name="STORAGES_STATICFILES_OPTIONS",
+                ),
+            },
         },
-        "staticfiles": {
-            "BACKEND": "richie.apps.core.storage.CDNManifestStaticFilesStorage",
-        },
-    }
+        environ_name="STORAGES",
+    )
     AWS_DEFAULT_ACL = None
     AWS_LOCATION = "media"
 
     AWS_ACCESS_KEY_ID = values.SecretValue()
     AWS_SECRET_ACCESS_KEY = values.SecretValue()
+    AWS_S3_REGION_NAME = values.Value("fr-par")
+    AWS_S3_ENDPOINT_URL = values.Value("https://s3.fr-par.scw.cloud")
 
     AWS_S3_OBJECT_PARAMETERS = {
         "Expires": "Thu, 31 Dec 2099 20:00:00 GMT",
         "CacheControl": "max-age=94608000",
     }
 
-    AWS_S3_REGION_NAME = values.Value("eu-west-1")
+    # CDN domain used to serve media files through the S3Storage
+    AWS_S3_CUSTOM_DOMAIN = values.Value(None)
+    AWS_STORAGE_BUCKET_NAME = values.Value("production-funcorporate-media")
+    AWS_S3_FILE_OVERWRITE = values.Value(False)
 
-    AWS_MEDIA_BUCKET_NAME = values.Value("production-funcorporate-media")
-
-    # CDN domain for static/media urls. It is passed to the frontend to load built chunks
-    CDN_DOMAIN = values.Value()
-
-    @property
-    def TEXT_CKEDITOR_BASE_PATH(self):  # pylint: disable=invalid-name
-        """Configure CKEditor with an absolute url as base path to point to CloudFront."""
-        return f"//{self.CDN_DOMAIN}/static/djangocms_text_ckeditor/ckeditor/"
+    # CDN domain for static urls. It is passed to the frontend to load built chunks.
+    CDN_DOMAIN = values.Value(None)
 
 
 class Feature(Production):
@@ -925,7 +943,7 @@ class Feature(Production):
     nota bene: it should inherit from the Production environment.
     """
 
-    AWS_MEDIA_BUCKET_NAME = values.Value("feature-funcorporate-media")
+    AWS_STORAGE_BUCKET_NAME = values.Value("feature-funcorporate-media")
 
 
 class Staging(Production):
@@ -935,7 +953,7 @@ class Staging(Production):
     nota bene: it should inherit from the Production environment.
     """
 
-    AWS_MEDIA_BUCKET_NAME = values.Value("staging-funcorporate-media")
+    AWS_STORAGE_BUCKET_NAME = values.Value("staging-funcorporate-media")
 
 
 class PreProduction(Production):
@@ -945,4 +963,4 @@ class PreProduction(Production):
     nota bene: it should inherit from the Production environment.
     """
 
-    AWS_MEDIA_BUCKET_NAME = values.Value("preprod-funcorporate-media")
+    AWS_STORAGE_BUCKET_NAME = values.Value("preprod-funcorporate-media")

--- a/sites/funmooc/CHANGELOG.md
+++ b/sites/funmooc/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Change settings to migrate media storage from AWS to Scaleway
+
 ## [1.43.2] - 2025-05-22
 
 ### Fixed

--- a/sites/funmooc/src/backend/funmooc/settings.py
+++ b/sites/funmooc/src/backend/funmooc/settings.py
@@ -1145,36 +1145,54 @@ class Production(Base):
     SECURE_CONTENT_TYPE_NOSNIFF = True
     SESSION_COOKIE_SECURE = True
 
-    STORAGES = {
-        "default": {
-            "BACKEND": "richie.apps.core.storage.MediaStorage",
+    # Using the S3Storage to be able to change the custom domain for media files without
+    # interfering with static files. Using the CDNManifestStaticFilesStorage with an
+    # undefined CDN_DOMAIN to use the custom `post_process` method.
+    STORAGES = values.DictValue(
+        {
+            "default": {
+                "BACKEND": values.Value(
+                    "storages.backends.s3.S3Storage",
+                    environ_name="STORAGES_DEFAULT_BACKEND",
+                ),
+                "OPTIONS": values.DictValue(
+                    {},
+                    environ_name="STORAGES_DEFAULT_OPTIONS",
+                ),
+            },
+            "staticfiles": {
+                "BACKEND": values.Value(
+                    "richie.apps.core.storage.CDNManifestStaticFilesStorage",
+                    environ_name="STORAGES_STATICFILES_BACKEND",
+                ),
+                "OPTIONS": values.DictValue(
+                    {},
+                    environ_name="STORAGES_STATICFILES_OPTIONS",
+                ),
+            },
         },
-        "staticfiles": {
-            "BACKEND": "richie.apps.core.storage.CDNManifestStaticFilesStorage",
-        },
-    }
+        environ_name="STORAGES",
+    )
     AWS_DEFAULT_ACL = None
     AWS_LOCATION = "media"
 
     AWS_ACCESS_KEY_ID = values.SecretValue()
     AWS_SECRET_ACCESS_KEY = values.SecretValue()
+    AWS_S3_REGION_NAME = values.Value("fr-par")
+    AWS_S3_ENDPOINT_URL = values.Value("https://s3.fr-par.scw.cloud")
 
     AWS_S3_OBJECT_PARAMETERS = {
         "Expires": "Thu, 31 Dec 2099 20:00:00 GMT",
         "CacheControl": "max-age=94608000",
     }
 
-    AWS_S3_REGION_NAME = values.Value("eu-west-1")
+    # CDN domain used to serve media files through the S3Storage
+    AWS_S3_CUSTOM_DOMAIN = values.Value(None)
+    AWS_STORAGE_BUCKET_NAME = values.Value("production-funmooc-media")
+    AWS_S3_FILE_OVERWRITE = values.Value(False)
 
-    AWS_MEDIA_BUCKET_NAME = values.Value("production-funmooc-media")
-
-    # CDN domain for static/media urls. It is passed to the frontend to load built chunks
+    # CDN domain for static urls. It is passed to the frontend to load built chunks.
     CDN_DOMAIN = values.Value()
-
-    @property
-    def TEXT_CKEDITOR_BASE_PATH(self):  # pylint: disable=invalid-name
-        """Configure CKEditor with an absolute url as base path to point to CloudFront."""
-        return f"//{self.CDN_DOMAIN}/static/djangocms_text_ckeditor/ckeditor/"
 
 
 class Feature(Production):
@@ -1184,7 +1202,7 @@ class Feature(Production):
     nota bene: it should inherit from the Production environment.
     """
 
-    AWS_MEDIA_BUCKET_NAME = values.Value("feature-funmooc-media")
+    AWS_STORAGE_BUCKET_NAME = values.Value("feature-funmooc-media")
 
 
 class Staging(Production):
@@ -1194,7 +1212,7 @@ class Staging(Production):
     nota bene: it should inherit from the Production environment.
     """
 
-    AWS_MEDIA_BUCKET_NAME = values.Value("staging-funmooc-media")
+    AWS_STORAGE_BUCKET_NAME = values.Value("staging-funmooc-media")
 
 
 class PreProduction(Production):
@@ -1204,4 +1222,4 @@ class PreProduction(Production):
     nota bene: it should inherit from the Production environment.
     """
 
-    AWS_MEDIA_BUCKET_NAME = values.Value("preprod-funmooc-media")
+    AWS_STORAGE_BUCKET_NAME = values.Value("preprod-funmooc-media")


### PR DESCRIPTION
## Purpose

Media files can now be stored on Scaleway instead of AWS.
Static files are no longer proxied through a CDN, as Scaleway Edge Services do not support this feature.

## Proposal

- [x] Testing on preprod with the `funcorporate` site
- [x] Changing the settings for all sites

To be able to change the custom domain for media files without interfering with static files, we are not using the `MediaStorage` backend anymore but the `S3Storage` backend along with its associated `AWS`-prefixed settings. 
We are also using the `CDNManifestStaticFileStorage` backend with an undefined `CDN_DOMAIN` setting to use the custom `post_process` method.

An IAM policy had to be added for the IAM application so it can read and write in the media buckets.