### PR TITLE
🔖(ademe/demo/funcampus/funcorporate/funmooc) bump to next minor versions

### DIFF
--- a/docs/scw.md
+++ b/docs/scw.md
@@ -114,6 +114,8 @@ $ bin/terraform --provider scw apply
 _nota bene_: in the previous pattern, we use the `workspace` `new` or `select`
 subcommand depending on the workspace availability.
 
+_Note_: When provisioning the Scaleway Edge Service with Terraform, the `fqdns` attribute (`scaleway_edge_services_dns_stage.media.fqdns`) is not immediately available during the initial `terraform apply`. This results in an "Invalid index" error when trying to output the FQDN. To work around this, you would need to apply a second time.
+
 ## Configure runtime environment
 
 Once your buckets have been created for a targeted environment, you will need

--- a/sites/ademe/CHANGELOG.md
+++ b/sites/ademe/CHANGELOG.md
@@ -9,6 +9,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.24.0] - 2025-06-25
+
 ### Changed
 
 - Change settings to migrate media storage from AWS to Scaleway
@@ -245,7 +247,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - First `ademe` image
 
-[unreleased]: https://github.com/openfun/fun-richie-site-factory/compare/ademe-0.23.2...HEAD
+[unreleased]: https://github.com/openfun/fun-richie-site-factory/compare/ademe-0.24.0...HEAD
+[0.24.0]: https://github.com/openfun/fun-richie-site-factory/compare/ademe-0.23.2...ademe-0.24.0
 [0.23.2]: https://github.com/openfun/fun-richie-site-factory/compare/ademe-0.23.1...ademe-0.23.2
 [0.23.1]: https://github.com/openfun/fun-richie-site-factory/compare/ademe-0.23.0...ademe-0.23.1
 [0.23.0]: https://github.com/openfun/fun-richie-site-factory/compare/ademe-0.22.0...ademe-0.23.0

--- a/sites/ademe/src/backend/ademe/__init__.py
+++ b/sites/ademe/src/backend/ademe/__init__.py
@@ -1,3 +1,3 @@
 """ademe application"""
 
-__version__ = "0.23.2"
+__version__ = "0.24.0"

--- a/sites/ademe/src/frontend/package.json
+++ b/sites/ademe/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ademe",
-  "version": "0.23.2",
+  "version": "0.24.0",
   "description": "Richie-powered CMS for www.mooc-batiment-durable.fr",
   "scripts": {
     "build-sass": "sass scss/_main.scss ../backend/base/static/richie/css/main.css --load-path=node_modules",

--- a/sites/demo/CHANGELOG.md
+++ b/sites/demo/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.29.0] - 2025-06-25
+
 ### Changed
 
 - Change settings to migrate media storage from AWS to Scaleway
@@ -376,7 +378,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 First demo image for richie to 2.0.0-beta.7
 
-[unreleased]: https://github.com/openfun/fun-richie-site-factory/compare/demo-1.28.2...HEAD
+[unreleased]: https://github.com/openfun/fun-richie-site-factory/compare/demo-1.29.0...HEAD
+[1.29.0]: https://github.com/openfun/fun-richie-site-factory/compare/demo-1.28.2...demo-1.29.0
 [1.28.2]: https://github.com/openfun/fun-richie-site-factory/compare/demo-1.28.1...demo-1.28.2
 [1.28.1]: https://github.com/openfun/fun-richie-site-factory/compare/demo-1.28.0...demo-1.28.1
 [1.28.0]: https://github.com/openfun/fun-richie-site-factory/compare/demo-1.27.1...demo-1.28.0

--- a/sites/demo/src/backend/demo/__init__.py
+++ b/sites/demo/src/backend/demo/__init__.py
@@ -1,3 +1,3 @@
 """demo application"""
 
-__version__ = "1.28.2"
+__version__ = "1.29.0"

--- a/sites/demo/src/frontend/package.json
+++ b/sites/demo/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "richie",
-  "version": "1.28.2",
+  "version": "1.29.0",
   "description": "Richie demo site on https://demo.richie.education",
   "scripts": {
     "build-ts": "tsc --noEmit && webpack --config node_modules/richie-education/webpack.config.js --output-path ../backend/base/static/richie/js/build --env richie-dependent-build --env richie-settings=overrides.json",

--- a/sites/funcampus/CHANGELOG.md
+++ b/sites/funcampus/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.29.0] - 2025-06-25
+
 ### Changed
 
 - Change settings to migrate media storage from AWS to Scaleway
@@ -352,7 +354,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - First `funcampus` image
 
-[unreleased]: https://github.com/openfun/fun-richie-site-factory/compare/funcampus-1.28.2...HEAD
+[unreleased]: https://github.com/openfun/fun-richie-site-factory/compare/funcampus-1.29.0...HEAD
+[1.29.0]: https://github.com/openfun/fun-richie-site-factory/compare/funcampus-1.28.2...funcampus-1.29.0
 [1.28.2]: https://github.com/openfun/fun-richie-site-factory/compare/funcampus-1.28.1...funcampus-1.28.2
 [1.28.1]: https://github.com/openfun/fun-richie-site-factory/compare/funcampus-1.28.0...funcampus-1.28.1
 [1.28.0]: https://github.com/openfun/fun-richie-site-factory/compare/funcampus-1.27.0...funcampus-1.28.0

--- a/sites/funcampus/src/backend/funcampus/__init__.py
+++ b/sites/funcampus/src/backend/funcampus/__init__.py
@@ -1,3 +1,3 @@
 """funcampus application"""
 
-__version__ = "1.28.2"
+__version__ = "1.29.0"

--- a/sites/funcampus/src/frontend/package.json
+++ b/sites/funcampus/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "funcampus",
-  "version": "1.28.2",
+  "version": "1.29.0",
   "description": "The future www.fun-campus.fr website based on https://github.com/openfun/richie",
   "scripts": {
     "build-ts": "tsc --noEmit && webpack --config node_modules/richie-education/webpack.config.js --output-path ../backend/base/static/richie/js/build --env richie-dependent-build --env richie-settings=overrides.json",

--- a/sites/funcorporate/CHANGELOG.md
+++ b/sites/funcorporate/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.29.0] - 2025-06-25
+
 ### Changed
 
 - Change settings to migrate media storage from AWS to Scaleway
@@ -422,7 +424,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Update project urls to add styleguide and account views.
 - Update layout color theme and logo to fit fun-corporate mockups.
 
-[unreleased]: https://github.com/openfun/fun-richie-site-factory/compare/funcorporate-1.28.2...HEAD
+[unreleased]: https://github.com/openfun/fun-richie-site-factory/compare/funcorporate-1.29.0...HEAD
+[1.29.0]: https://github.com/openfun/fun-richie-site-factory/compare/funcorporate-1.28.2...funcorporate-1.29.0
 [1.28.2]: https://github.com/openfun/fun-richie-site-factory/compare/funcorporate-1.28.1...funcorporate-1.28.2
 [1.28.1]: https://github.com/openfun/fun-richie-site-factory/compare/funcorporate-1.28.0...funcorporate-1.28.1
 [1.28.0]: https://github.com/openfun/fun-richie-site-factory/compare/funcorporate-1.27.0...funcorporate-1.28.0

--- a/sites/funcorporate/src/backend/funcorporate/__init__.py
+++ b/sites/funcorporate/src/backend/funcorporate/__init__.py
@@ -1,3 +1,3 @@
 """FUN Corporate application"""
 
-__version__ = "1.28.2"
+__version__ = "1.29.0"

--- a/sites/funcorporate/src/frontend/package.json
+++ b/sites/funcorporate/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "funcorporate",
-  "version": "1.28.2",
+  "version": "1.29.0",
   "description": "The future www.fun-corporate.fr website based on https://github.com/openfun/richie",
   "scripts": {
     "build-ts": "tsc --noEmit && webpack --config node_modules/richie-education/webpack.config.js --output-path ../backend/base/static/richie/js/build --env richie-dependent-build --env richie-settings=overrides.json",

--- a/sites/funmooc/CHANGELOG.md
+++ b/sites/funmooc/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.44.0] - 2025-06-25
+
 ### Changed
 
 - Change settings to migrate media storage from AWS to Scaleway
@@ -841,7 +843,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Static and media files are stored in AWS S3 buckets and distributed _via_
   Amazon CloudFront
 
-[unreleased]: https://github.com/openfun/fun-richie-site-factory/compare/funmooc-1.43.2...HEAD
+[unreleased]: https://github.com/openfun/fun-richie-site-factory/compare/funmooc-1.44.0...HEAD
+[1.44.0]: https://github.com/openfun/fun-richie-site-factory/compare/funmooc-1.43.2...funmooc-1.44.0
 [1.43.2]: https://github.com/openfun/fun-richie-site-factory/compare/funmooc-1.43.1...funmooc-1.43.2
 [1.43.1]: https://github.com/openfun/fun-richie-site-factory/compare/funmooc-1.43.0...funmooc-1.43.1
 [1.43.0]: https://github.com/openfun/fun-richie-site-factory/compare/funmooc-1.42.0...funmooc-1.43.0

--- a/sites/funmooc/requirements/base.txt
+++ b/sites/funmooc/requirements/base.txt
@@ -8,5 +8,5 @@ dockerflow==2024.4.2
 factory-boy==3.3.3
 gunicorn==23.0.0
 psycopg2-binary==2.9.10
-richie==3.1.3.dev7
+richie==3.1.2
 sentry-sdk==2.24.1

--- a/sites/funmooc/src/backend/funmooc/__init__.py
+++ b/sites/funmooc/src/backend/funmooc/__init__.py
@@ -1,3 +1,3 @@
 """funmooc application"""
 
-__version__ = "1.43.2"
+__version__ = "1.44.0"

--- a/sites/funmooc/src/frontend/package.json
+++ b/sites/funmooc/src/frontend/package.json
@@ -36,7 +36,7 @@
   },
   "homepage": "https://github.com/openfun/fun-richie-site-factory#readme",
   "dependencies": {
-    "richie-education": "3.1.3.dev7",
+    "richie-education": "3.1.2",
     "tarteaucitronjs": "1.14.0"
   },
   "devDependencies": {

--- a/sites/funmooc/src/frontend/package.json
+++ b/sites/funmooc/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "funmooc",
-  "version": "1.43.2",
+  "version": "1.44.0",
   "description": "Richie-powered CMS for fun-mooc.fr",
   "scripts": {
     "build-sass": "sass scss/_main.scss ../backend/base/static/richie/css/main.css --load-path=node_modules",

--- a/sites/funmooc/src/frontend/yarn.lock
+++ b/sites/funmooc/src/frontend/yarn.lock
@@ -10257,10 +10257,10 @@ reusify@^1.0.4:
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
   integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
 
-richie-education@3.1.3.dev7:
-  version "3.1.3-dev7"
-  resolved "https://registry.yarnpkg.com/richie-education/-/richie-education-3.1.3-dev7.tgz#776b5be11e392799ce48dc4f5be77ef8b658c80b"
-  integrity sha512-zuIuQplw78S+3qg63OvS2a/ciTs+0aRXUtTf1FaDAnX0iHdJMR2yjjULiu0wtLvU1JwLpUMQh5E19iJDJLRqTA==
+richie-education@3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/richie-education/-/richie-education-3.1.2.tgz#733251076e9229549af722b080e413a6fd427e84"
+  integrity sha512-lAug7SU3esY3vm726anjn55mVuSfDC0fJ0wF8OVmRww8Ti0Ep06KR1RVErp8rCx4imU4urnZsAVX4c6/8EVhFw==
   dependencies:
     "@babel/core" "7.26.10"
     "@babel/plugin-syntax-dynamic-import" "7.8.3"
@@ -10774,16 +10774,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -10888,14 +10879,7 @@ string.prototype.trimstart@^1.0.8:
     define-properties "^1.2.1"
     es-object-atoms "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -11842,7 +11826,7 @@ wildcard@^2.0.1:
   resolved "https://registry.yarnpkg.com/wildcard/-/wildcard-2.0.1.tgz#5ab10d02487198954836b6349f74fff961e10f67"
   integrity sha512-CC1bOL87PIWSBhDcTrdeLo6eGT7mCFtrg0uIJtqJUFyK+eJnzl8A1niH56uu7KMa5XFrtiV+AQuHO3n7DsHnLQ==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -11855,15 +11839,6 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
## Purpose

Downgrading the richie version on funmooc site to be able to make a stable release with the CDN changes.
The version will be reverted back to `3.1.3.dev7` after the release.

## Proposal

For all sites:

### Changed

- Change settings to migrate media storage from AWS to Scaleway
