### PR TITLE
⬆(funmooc) upgrade richie to v3.1.3.dev27

### DIFF
--- a/sites/funmooc/requirements/base.txt
+++ b/sites/funmooc/requirements/base.txt
@@ -8,5 +8,5 @@ dockerflow==2024.4.2
 factory-boy==3.3.3
 gunicorn==23.0.0
 psycopg2-binary==2.9.10
-richie==3.1.3.dev17
+richie==3.1.3.dev27
 sentry-sdk==2.24.1

--- a/sites/funmooc/src/frontend/package.json
+++ b/sites/funmooc/src/frontend/package.json
@@ -36,7 +36,7 @@
   },
   "homepage": "https://github.com/openfun/fun-richie-site-factory#readme",
   "dependencies": {
-    "richie-education": "3.1.3.dev17",
+    "richie-education": "3.1.3.dev27",
     "tarteaucitronjs": "1.14.0"
   },
   "devDependencies": {

--- a/sites/funmooc/src/frontend/yarn.lock
+++ b/sites/funmooc/src/frontend/yarn.lock
@@ -10257,10 +10257,10 @@ reusify@^1.0.4:
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
   integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
 
-richie-education@3.1.3.dev17:
-  version "3.1.3-dev17"
-  resolved "https://registry.yarnpkg.com/richie-education/-/richie-education-3.1.3-dev17.tgz#18353ae06085a49145709b2691199940612a3cdf"
-  integrity sha512-qQqPAJB8zVC2/HOBgWopO2LDLKbydoZfnYL3alupsooydfl2uESEbs/qhn0sA7nSGyBOBq9KuY9En5mQ4Ytobg==
+richie-education@3.1.3.dev27:
+  version "3.1.3-dev27"
+  resolved "https://registry.yarnpkg.com/richie-education/-/richie-education-3.1.3-dev27.tgz#02ccf28f02d7e699a318ce2a06c018db1c667ff6"
+  integrity sha512-YlKVU1fEw3oXEpSXKPuIbvye0lOBThpU2vp84fLeqqgtLUcHQikBKNOYp03Zn0p99LqeBBxBxHbDVmTnQbgL1g==
   dependencies:
     "@babel/core" "7.26.10"
     "@babel/plugin-syntax-dynamic-import" "7.8.3"


### PR DESCRIPTION
Changelog available at:
https://github.com/openfun/richie/releases/tag/v3.1.3.dev27