### PR TITLE
🚚(demo) update S3 bucket names to match provisioned on Scaleway

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -431,11 +431,66 @@ workflows:
                 - << pipeline.schedule.name >>
     demo:
         jobs:
-            - no-change:
+            - check-changelog:
+                filters:
+                    branches:
+                        ignore: main
+                name: check-changelog-demo
+                site: demo
+            - lint-changelog:
+                filters:
+                    branches:
+                        ignore: main
+                    tags:
+                        only: /^demo-.*/
+                name: lint-changelog--demo
+                site: demo
+            - build-front-production:
                 filters:
                     tags:
-                        only: /.*/
-                name: no-change-demo
+                        only: /^demo-.*/
+                name: build-front-production-demo
+                site: demo
+            - lint-front:
+                filters:
+                    tags:
+                        only: /^demo-.*/
+                name: lint-front-demo
+                requires:
+                    - build-front-production-demo
+                site: demo
+            - build-back:
+                filters:
+                    tags:
+                        only: /^demo-.*/
+                name: build-back-demo
+                site: demo
+            - lint-back:
+                filters:
+                    tags:
+                        only: /^demo-.*/
+                name: lint-back-demo
+                requires:
+                    - build-back-demo
+                site: demo
+            - test-back:
+                filters:
+                    tags:
+                        only: /^demo-.*/
+                name: test-back-demo
+                requires:
+                    - build-back-demo
+                site: demo
+            - hub:
+                filters:
+                    tags:
+                        only: /^demo-.*/
+                image_name: richie-demo
+                name: hub-demo
+                requires:
+                    - lint-front-demo
+                    - lint-back-demo
+                site: demo
     funcampus:
         jobs:
             - no-change:
@@ -452,66 +507,11 @@ workflows:
                 name: no-change-funcorporate
     funmooc:
         jobs:
-            - check-changelog:
-                filters:
-                    branches:
-                        ignore: main
-                name: check-changelog-funmooc
-                site: funmooc
-            - lint-changelog:
-                filters:
-                    branches:
-                        ignore: main
-                    tags:
-                        only: /^funmooc-.*/
-                name: lint-changelog--funmooc
-                site: funmooc
-            - build-front-production:
+            - no-change:
                 filters:
                     tags:
-                        only: /^funmooc-.*/
-                name: build-front-production-funmooc
-                site: funmooc
-            - lint-front:
-                filters:
-                    tags:
-                        only: /^funmooc-.*/
-                name: lint-front-funmooc
-                requires:
-                    - build-front-production-funmooc
-                site: funmooc
-            - build-back:
-                filters:
-                    tags:
-                        only: /^funmooc-.*/
-                name: build-back-funmooc
-                site: funmooc
-            - lint-back:
-                filters:
-                    tags:
-                        only: /^funmooc-.*/
-                name: lint-back-funmooc
-                requires:
-                    - build-back-funmooc
-                site: funmooc
-            - test-back:
-                filters:
-                    tags:
-                        only: /^funmooc-.*/
-                name: test-back-funmooc
-                requires:
-                    - build-back-funmooc
-                site: funmooc
-            - hub:
-                filters:
-                    tags:
-                        only: /^funmooc-.*/
-                image_name: funmooc
-                name: hub-funmooc
-                requires:
-                    - lint-front-funmooc
-                    - lint-back-funmooc
-                site: funmooc
+                        only: /.*/
+                name: no-change-funmooc
     site-factory:
         jobs:
             - lint-git:

--- a/sites/demo/CHANGELOG.md
+++ b/sites/demo/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Update S3 bucket names to match those provisioned on Scaleway
+
 ## [1.29.0] - 2025-06-25
 
 ### Changed

--- a/sites/demo/src/backend/demo/settings.py
+++ b/sites/demo/src/backend/demo/settings.py
@@ -802,7 +802,7 @@ class Production(Base):
 
     # CDN domain used to serve media files through the S3Storage
     AWS_S3_CUSTOM_DOMAIN = values.Value(None)
-    AWS_STORAGE_BUCKET_NAME = values.Value("production-richie-media")
+    AWS_STORAGE_BUCKET_NAME = values.Value("production-demo-media")
     AWS_S3_FILE_OVERWRITE = values.Value(False)
 
     # CDN domain for static urls. It is passed to the frontend to load built chunks.
@@ -816,7 +816,7 @@ class Feature(Production):
     nota bene: it should inherit from the Production environment.
     """
 
-    AWS_STORAGE_BUCKET_NAME = values.Value("feature-richie-media")
+    AWS_STORAGE_BUCKET_NAME = values.Value("feature-demo-media")
 
 
 class Staging(Production):
@@ -826,7 +826,7 @@ class Staging(Production):
     nota bene: it should inherit from the Production environment.
     """
 
-    AWS_STORAGE_BUCKET_NAME = values.Value("staging-richie-media")
+    AWS_STORAGE_BUCKET_NAME = values.Value("staging-demo-media")
 
 
 class PreProduction(Production):
@@ -836,4 +836,4 @@ class PreProduction(Production):
     nota bene: it should inherit from the Production environment.
     """
 
-    AWS_STORAGE_BUCKET_NAME = values.Value("preprod-richie-media")
+    AWS_STORAGE_BUCKET_NAME = values.Value("preprod-demo-media")


### PR DESCRIPTION
## Purpose

The bucket `production-demo-media` was created on Scaleway following the same naming convention as other sites (\<environment\>-\<site\>-media). 

## Proposal

Update all demo bucket names from `<environment>-richie-media` to `<environment>-demo-media`.