### PR TITLE
🔖(demo) bump to version 1.29.1

### DIFF
--- a/sites/demo/CHANGELOG.md
+++ b/sites/demo/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.29.1] - 2025-07-09
+
 ### Fixed
 
 - Update S3 bucket names to match those provisioned on Scaleway
@@ -382,7 +384,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 First demo image for richie to 2.0.0-beta.7
 
-[unreleased]: https://github.com/openfun/fun-richie-site-factory/compare/demo-1.29.0...HEAD
+[unreleased]: https://github.com/openfun/fun-richie-site-factory/compare/demo-1.29.1...HEAD
+[1.29.1]: https://github.com/openfun/fun-richie-site-factory/compare/demo-1.29.0...demo-1.29.1
 [1.29.0]: https://github.com/openfun/fun-richie-site-factory/compare/demo-1.28.2...demo-1.29.0
 [1.28.2]: https://github.com/openfun/fun-richie-site-factory/compare/demo-1.28.1...demo-1.28.2
 [1.28.1]: https://github.com/openfun/fun-richie-site-factory/compare/demo-1.28.0...demo-1.28.1

--- a/sites/demo/src/backend/demo/__init__.py
+++ b/sites/demo/src/backend/demo/__init__.py
@@ -1,3 +1,3 @@
 """demo application"""
 
-__version__ = "1.29.0"
+__version__ = "1.29.1"

--- a/sites/demo/src/frontend/package.json
+++ b/sites/demo/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "richie",
-  "version": "1.29.0",
+  "version": "1.29.1",
   "description": "Richie demo site on https://demo.richie.education",
   "scripts": {
     "build-ts": "tsc --noEmit && webpack --config node_modules/richie-education/webpack.config.js --output-path ../backend/base/static/richie/js/build --env richie-dependent-build --env richie-settings=overrides.json",


### PR DESCRIPTION
### Fixed

- Update S3 bucket names to match those provisioned on Scaleway
