### PR TITLE
✨(backend) add JS_NEXT_URL setting to all sites

### DIFF
--- a/sites/ademe/CHANGELOG.md
+++ b/sites/ademe/CHANGELOG.md
@@ -9,6 +9,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Add configurable `JS_NEXT_URL` setting to LMS backend (`EDX_JS_NEXT_URL`)
+
 ## [0.26.0] - 2025-11-03
 
 ### Changed

--- a/sites/ademe/src/backend/ademe/settings.py
+++ b/sites/ademe/src/backend/ademe/settings.py
@@ -364,6 +364,11 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
                 environ_prefix=None,
             ),
             "BASE_URL": values.Value(environ_name="EDX_BASE_URL", environ_prefix=None),
+            "JS_NEXT_URL": values.Value(
+                "richie",
+                environ_name="EDX_JS_NEXT_URL",
+                environ_prefix=None,
+            ),
         }
     ]
     RICHIE_COURSE_RUN_SYNC_SECRETS = values.ListValue([])

--- a/sites/demo/CHANGELOG.md
+++ b/sites/demo/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Add configurable `JS_NEXT_URL` setting to LMS backend (`EDX_JS_NEXT_URL`)
+
 ## [1.31.0] - 2025-11-03
 
 ### Changed

--- a/sites/demo/src/backend/demo/settings.py
+++ b/sites/demo/src/backend/demo/settings.py
@@ -268,6 +268,11 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
                 environ_prefix=None,
             ),
             "BASE_URL": values.Value(environ_name="EDX_BASE_URL", environ_prefix=None),
+            "JS_NEXT_URL": values.Value(
+                "richie",
+                environ_name="EDX_JS_NEXT_URL",
+                environ_prefix=None,
+            ),
         }
     ]
     RICHIE_COURSE_RUN_SYNC_SECRETS = values.ListValue([])

--- a/sites/funcampus/CHANGELOG.md
+++ b/sites/funcampus/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Add `RICHIE_LMS_BACKENDS` configuration with configurable `JS_NEXT_URL` setting (`EDX_JS_NEXT_URL`)
+
 ## [1.31.0] - 2025-11-03
 
 ### Changed

--- a/sites/funcampus/src/backend/funcampus/settings.py
+++ b/sites/funcampus/src/backend/funcampus/settings.py
@@ -422,6 +422,39 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
     # when their preferred language, whatever it is, is unavailable
     LANGUAGES = (("en", _("English")), ("fr", _("French")))
 
+    # LMS
+    RICHIE_LMS_BACKENDS = [
+        {
+            "BACKEND": values.Value(
+                "richie.apps.courses.lms.edx.EdXLMSBackend",
+                environ_name="EDX_BACKEND",
+                environ_prefix=None,
+            ),
+            "JS_BACKEND": values.Value(
+                "openedx-hawthorn",
+                environ_name="EDX_JS_BACKEND",
+                environ_prefix=None,
+            ),
+            "COURSE_REGEX": values.Value(
+                r"^.*/courses/(?P<course_id>.*)/course/?$",
+                environ_name="EDX_COURSE_REGEX",
+                environ_prefix=None,
+            ),
+            "JS_COURSE_REGEX": values.Value(
+                r"^.*/courses/(.*)/course/?$",
+                environ_name="EDX_JS_COURSE_REGEX",
+                environ_prefix=None,
+            ),
+            "BASE_URL": values.Value(environ_name="EDX_BASE_URL", environ_prefix=None),
+            "JS_NEXT_URL": values.Value(
+                "richie",
+                environ_name="EDX_JS_NEXT_URL",
+                environ_prefix=None,
+            ),
+        }
+    ]
+    RICHIE_COURSE_RUN_SYNC_SECRETS = values.ListValue([])
+
     # CMS
     # Minimum enrollment count value that would be shown on course detail page
     RICHIE_MINIMUM_COURSE_RUNS_ENROLLMENT_COUNT = values.Value(

--- a/sites/funcorporate/CHANGELOG.md
+++ b/sites/funcorporate/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Add `RICHIE_LMS_BACKENDS` configuration with configurable `JS_NEXT_URL` setting (`EDX_JS_NEXT_URL`)
+
 ## [1.31.0] - 2025-11-03
 
 ### Changed

--- a/sites/funcorporate/src/backend/funcorporate/settings.py
+++ b/sites/funcorporate/src/backend/funcorporate/settings.py
@@ -326,6 +326,39 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
     # when their preferred language, whatever it is, is unavailable
     LANGUAGES = (("en", _("English")), ("fr", _("French")))
 
+    # LMS
+    RICHIE_LMS_BACKENDS = [
+        {
+            "BACKEND": values.Value(
+                "richie.apps.courses.lms.edx.EdXLMSBackend",
+                environ_name="EDX_BACKEND",
+                environ_prefix=None,
+            ),
+            "JS_BACKEND": values.Value(
+                "openedx-hawthorn",
+                environ_name="EDX_JS_BACKEND",
+                environ_prefix=None,
+            ),
+            "COURSE_REGEX": values.Value(
+                r"^.*/courses/(?P<course_id>.*)/course/?$",
+                environ_name="EDX_COURSE_REGEX",
+                environ_prefix=None,
+            ),
+            "JS_COURSE_REGEX": values.Value(
+                r"^.*/courses/(.*)/course/?$",
+                environ_name="EDX_JS_COURSE_REGEX",
+                environ_prefix=None,
+            ),
+            "BASE_URL": values.Value(environ_name="EDX_BASE_URL", environ_prefix=None),
+            "JS_NEXT_URL": values.Value(
+                "richie",
+                environ_name="EDX_JS_NEXT_URL",
+                environ_prefix=None,
+            ),
+        }
+    ]
+    RICHIE_COURSE_RUN_SYNC_SECRETS = values.ListValue([])
+
     # CMS
     # Minimum enrollment count value that would be shown on course detail page
     RICHIE_MINIMUM_COURSE_RUNS_ENROLLMENT_COUNT = values.Value(

--- a/sites/funmooc/CHANGELOG.md
+++ b/sites/funmooc/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Add configurable `JS_NEXT_URL` setting to LMS backend (`EDX_JS_NEXT_URL`)
+
 ## [1.49.0] - 2026-04-09
 
 ### Changed

--- a/sites/funmooc/src/backend/funmooc/settings.py
+++ b/sites/funmooc/src/backend/funmooc/settings.py
@@ -367,6 +367,11 @@ class Base(StyleguideMixin, DRFMixin, RichieCoursesConfigurationMixin, Configura
                 environ_prefix=None,
             ),
             "BASE_URL": values.Value(environ_name="EDX_BASE_URL", environ_prefix=None),
+            "JS_NEXT_URL": values.Value(
+                "richie",
+                environ_name="EDX_JS_NEXT_URL",
+                environ_prefix=None,
+            ),
         }
     ]
     RICHIE_COURSE_RUN_SYNC_SECRETS = values.ListValue([])


### PR DESCRIPTION
Add JS_NEXT_URL setting to RICHIE_LMS_BACKENDS for all sites, exposing the EDX_JS_NEXT_URL environment variable that controls the prefix used in the ?next= parameter during login/registerredirects in the OpenEdX Hawthorn API.